### PR TITLE
feat: add pagination, sorting, and walletAddress filtering to getGrou…

### DIFF
--- a/ahjoorxmr/src/contributions/contributions.controller.ts
+++ b/ahjoorxmr/src/contributions/contributions.controller.ts
@@ -3,6 +3,7 @@ import { Throttle } from '@nestjs/throttler';
 import { ContributionsService } from './contributions.service';
 import { CreateContributionDto } from './dto/create-contribution.dto';
 import { ContributionResponseDto } from './dto/contribution-response.dto';
+import { GetContributionsQueryDto } from './dto/get-contributions-query.dto';
 import { ApiKeyGuard } from './guards/api-key.guard';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
@@ -12,7 +13,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
  */
 @Controller('api/v1')
 export class ContributionsController {
-  constructor(private readonly contributionsService: ContributionsService) {}
+  constructor(private readonly contributionsService: ContributionsService) { }
 
   /**
    * Creates a new contribution record (internal endpoint).
@@ -52,38 +53,40 @@ export class ContributionsController {
   }
 
   /**
-   * Retrieves all contributions for a specific group.
-   * Optionally filters by round number via query parameter.
+   * Retrieves all contributions for a specific group with pagination, sorting, and filtering.
    *
    * @param groupId - The UUID of the group
-   * @param round - Optional round number to filter by
-   * @returns Array of contributions for the group
-   * @throws BadRequestException if groupId is not a valid UUID or round is invalid
+   * @param query - The pagination and filter query parameters
+   * @returns Paginated envelope containing contributions for the group
+   * @throws BadRequestException if groupId is not a valid UUID
    * @throws NotFoundException if the group doesn't exist
    */
   @Get('groups/:id/contributions')
   async getGroupContributions(
     @Param('id', ParseUUIDPipe) groupId: string,
-    @Query('round', new ParseIntPipe({ optional: true })) round?: number,
-  ): Promise<ContributionResponseDto[]> {
-    const contributions = await this.contributionsService.getGroupContributions(
+    @Query() query: GetContributionsQueryDto,
+  ): Promise<{ data: ContributionResponseDto[]; total: number; page: number; limit: number; totalPages: number }> {
+    const result = await this.contributionsService.getGroupContributions(
       groupId,
-      round,
+      query,
     );
 
     // Transform entities to response DTOs with ISO date strings
-    return contributions.map((contribution) => ({
-      id: contribution.id,
-      groupId: contribution.groupId,
-      userId: contribution.userId,
-      walletAddress: contribution.walletAddress,
-      roundNumber: contribution.roundNumber,
-      amount: contribution.amount,
-      transactionHash: contribution.transactionHash,
-      timestamp: contribution.timestamp.toISOString(),
-      createdAt: contribution.createdAt.toISOString(),
-      updatedAt: contribution.updatedAt.toISOString(),
-    }));
+    return {
+      ...result,
+      data: result.data.map((contribution) => ({
+        id: contribution.id,
+        groupId: contribution.groupId,
+        userId: contribution.userId,
+        walletAddress: contribution.walletAddress,
+        roundNumber: contribution.roundNumber,
+        amount: contribution.amount,
+        transactionHash: contribution.transactionHash,
+        timestamp: contribution.timestamp.toISOString(),
+        createdAt: contribution.createdAt.toISOString(),
+        updatedAt: contribution.updatedAt.toISOString(),
+      })),
+    };
   }
 
   /**

--- a/ahjoorxmr/src/contributions/dto/get-contributions-query.dto.ts
+++ b/ahjoorxmr/src/contributions/dto/get-contributions-query.dto.ts
@@ -1,0 +1,37 @@
+import { IsOptional, IsInt, Min, Max, IsString, IsIn, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetContributionsQueryDto {
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    page?: number = 1;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    @Type(() => Number)
+    limit?: number = 20;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    round?: number;
+
+    @IsOptional()
+    @IsString()
+    walletAddress?: string;
+
+    @IsOptional()
+    @IsString()
+    @IsIn(['timestamp', 'amount'])
+    sortBy?: string = 'timestamp';
+
+    @IsOptional()
+    @IsString()
+    @IsIn(['ASC', 'DESC'])
+    sortOrder?: 'ASC' | 'DESC' = 'DESC';
+}


### PR DESCRIPTION
resolves #37 
Key Changes
Pagination: Added page and limit support to GET /api/v1/groups/:id/contributions (default 20, max 100).
Sorting: Added sortBy (timestamp/amount) and sortOrder (ASC/DESC) support.
Member Filtering: Added walletAddress as a new filter parameter.
Paginated Response: The endpoint now returns a structured envelope { data, total, page, limit, totalPages }.
Validation: Introduced GetContributionsQueryDto for robust query parameter validation.