### PR TITLE
implemented Soft Delete / Archive Completed Groups

### DIFF
--- a/ahjoorxmr/migrations/1772100000000-AddGroupSoftDelete.ts
+++ b/ahjoorxmr/migrations/1772100000000-AddGroupSoftDelete.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGroupSoftDelete1772100000000 implements MigrationInterface {
+  name = 'AddGroupSoftDelete1772100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "groups"
+      ADD COLUMN IF NOT EXISTS "deletedAt" timestamp NULL DEFAULT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_groups_deletedAt"
+      ON "groups" ("deletedAt")
+      WHERE "deletedAt" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_groups_deletedAt"`);
+    await queryRunner.query(`ALTER TABLE "groups" DROP COLUMN IF EXISTS "deletedAt"`);
+  }
+}

--- a/ahjoorxmr/src/groups/entities/group.entity.ts
+++ b/ahjoorxmr/src/groups/entities/group.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, DeleteDateColumn } from 'typeorm';
 import { BaseEntity } from '../../common/entities/base.entity';
 import { GroupStatus } from './group-status.enum';
 import { Membership } from '../../memberships/entities/membership.entity';
@@ -42,6 +42,9 @@ export class Group extends BaseEntity {
 
   @Column('int')
   minMembers: number;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date | null;
 
   @OneToMany(() => Membership, (membership) => membership.group)
   memberships: Membership[];

--- a/ahjoorxmr/src/groups/groups.controller.ts
+++ b/ahjoorxmr/src/groups/groups.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Get,
   Patch,
+  Delete,
   Body,
   Param,
   Query,
@@ -13,6 +14,7 @@ import {
   Request,
   ParseIntPipe,
   DefaultValuePipe,
+  ParseBoolPipe,
   Version,
 } from '@nestjs/common';
 import {
@@ -123,6 +125,13 @@ export class GroupsController {
     description: 'Items per page',
     example: 10,
   })
+  @ApiQuery({
+    name: 'includeArchived',
+    required: false,
+    type: Boolean,
+    description: 'Include soft-deleted groups',
+    example: false,
+  })
   @ApiResponse({
     status: 200,
     description: 'Successfully retrieved groups',
@@ -131,8 +140,10 @@ export class GroupsController {
   async findAll(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('includeArchived', new DefaultValuePipe(false), ParseBoolPipe)
+    includeArchived: boolean,
   ): Promise<PaginatedGroupsResponseDto> {
-    const result = await this.groupsService.findAll(page, limit);
+    const result = await this.groupsService.findAll(page, limit, includeArchived);
     return {
       data: result.data.map((g) => this.toGroupResponse(g)),
       total: result.total,
@@ -264,6 +275,36 @@ export class GroupsController {
       adminWallet,
     );
     return this.toGroupResponse(group);
+  }
+
+  /**
+   * Soft-deletes a group (archive). Admin-only — only the group admin may delete.
+   *
+   * @param req - Authenticated request object
+   * @param id - The UUID of the group
+   * @throws NotFoundException if the group doesn't exist
+   * @throws ForbiddenException if not the group admin
+   */
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Archive (soft-delete) a group',
+    description: 'Soft-deletes a group by setting deletedAt. Only the group admin can delete.',
+  })
+  @ApiParam({ name: 'id', description: 'Group UUID', format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Group archived successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized', type: ErrorResponseDto })
+  @ApiResponse({ status: 403, description: 'Forbidden - only group admin can delete', type: ErrorResponseDto })
+  @ApiResponse({ status: 404, description: 'Group not found', type: ErrorResponseDto })
+  @AuditLog({ action: 'DELETE', resource: 'GROUP' })
+  async remove(
+    @Request() req: { user: { id: string; walletAddress: string } },
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    const adminWallet = req.user.walletAddress || req.user.id;
+    await this.groupsService.softDelete(id, adminWallet);
   }
 
   /**

--- a/ahjoorxmr/src/groups/groups.service.ts
+++ b/ahjoorxmr/src/groups/groups.service.ts
@@ -77,28 +77,37 @@ export class GroupsService {
 
   /**
    * Returns a paginated list of all ROSCA groups ordered by creation date (newest first).
+   * Soft-deleted groups are excluded by default unless includeArchived is true.
    *
    * @param page - Page number (1-indexed)
    * @param limit - Number of items per page
+   * @param includeArchived - Whether to include soft-deleted groups
    * @returns Paginated result with data, total count, page, and limit
    */
   async findAll(
     page: number = 1,
     limit: number = 10,
+    includeArchived: boolean = false,
   ): Promise<{ data: Group[]; total: number; page: number; limit: number }> {
     this.logger.log(
-      `Fetching groups page=${page} limit=${limit}`,
+      `Fetching groups page=${page} limit=${limit} includeArchived=${includeArchived}`,
       'GroupsService',
     );
 
     try {
       const skip = (page - 1) * limit;
 
-      const [data, total] = await this.groupRepository.findAndCount({
-        order: { createdAt: 'DESC' },
-        skip,
-        take: limit,
-      });
+      const qb = this.groupRepository
+        .createQueryBuilder('group')
+        .orderBy('group.createdAt', 'DESC')
+        .skip(skip)
+        .take(limit);
+
+      if (includeArchived) {
+        qb.withDeleted();
+      }
+
+      const [data, total] = await qb.getManyAndCount();
 
       this.logger.log(
         `Found ${total} group(s); returning page ${page}`,
@@ -226,6 +235,7 @@ export class GroupsService {
 
   /**
    * Returns all groups that the authenticated user (by userId) belongs to as a member.
+   * Excludes soft-deleted groups.
    *
    * @param userId - The UUID of the authenticated user
    * @returns Array of Group entities the user is a member of
@@ -239,7 +249,9 @@ export class GroupsService {
         relations: ['group'],
       });
 
-      const groups = memberships.map((m) => m.group).filter(Boolean);
+      const groups = memberships
+        .map((m) => m.group)
+        .filter((g) => g && !g.deletedAt);
 
       this.logger.log(
         `Found ${groups.length} group(s) for user ${userId}`,
@@ -255,6 +267,41 @@ export class GroupsService {
       );
       throw error;
     }
+  }
+
+  /**
+   * Soft-deletes a group by setting deletedAt timestamp.
+   * Only the group admin can delete the group.
+   *
+   * @param id - The UUID of the group
+   * @param adminWallet - Wallet address of the requesting admin
+   * @throws NotFoundException if the group doesn't exist
+   * @throws ForbiddenException if the requester is not the group admin
+   */
+  async softDelete(id: string, adminWallet: string): Promise<void> {
+    this.logger.log(
+      `Soft-deleting group ${id} by admin ${adminWallet}`,
+      'GroupsService',
+    );
+
+    const group = await this.groupRepository.findOne({ where: { id } });
+
+    if (!group) {
+      this.logger.warn(`Group ${id} not found for deletion`, 'GroupsService');
+      throw new NotFoundException(`Group with id ${id} not found`);
+    }
+
+    if (group.adminWallet !== adminWallet) {
+      this.logger.warn(
+        `Admin wallet mismatch: ${adminWallet} is not the admin of group ${id}`,
+        'GroupsService',
+      );
+      throw new ForbiddenException('Only the group admin can delete this group');
+    }
+
+    await this.groupRepository.softDelete(id);
+
+    this.logger.log(`Group ${id} soft-deleted successfully`, 'GroupsService');
   }
 
   /**


### PR DESCRIPTION
## what was done:

group.entity.ts — added @DeleteDateColumn() deletedAt: Date | null. TypeORM automatically excludes rows where deletedAt IS NOT NULL from all standard queries.

groups.service.ts:
findAll now accepts includeArchived: boolean and uses a query builder with .withDeleted() when opted in
findMyGroups filters out groups where deletedAt is set (since memberships are loaded via relation, not direct query)
New softDelete(id, adminWallet) method — checks existence and admin ownership, then calls repository.softDelete(id)
groups.controller.ts:

findAll gets the ?includeArchived=true query param via ParseBoolPipe
New DELETE /api/v1/groups/:id endpoint — JWT-guarded, returns 204, delegates to softDelete
1772100000000-AddGroupSoftDelete.ts
 — adds the deletedAt nullable timestamp column to the groups table with a partial index for performance.
 
 Close #90 