### PR TITLE
feat : implement Scheduler to  Detect and Flag Groups Stuck

### DIFF
--- a/ahjoorxmr/.env.example
+++ b/ahjoorxmr/.env.example
@@ -68,3 +68,6 @@ TRUSTED_IP_RANGES=10.0.0.1-10.0.0.255,172.16.0.1-172.16.255.255
 # Example: TRUSTED_IP_RANGES=192.168.1.1-192.168.1.255
 
 VERIFY_CONTRIBUTIONS=true
+
+# Stale Group Detection Configuration
+MAX_STALE_GROUP_DAYS=7            # Number of days before an ACTIVE group is flagged as stale

--- a/ahjoorxmr/migrations/1740500000000-AddStaleAtToGroups.ts
+++ b/ahjoorxmr/migrations/1740500000000-AddStaleAtToGroups.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddStaleAtToGroups1740500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'groups',
+      new TableColumn({
+        name: 'staleAt',
+        type: 'timestamp',
+        isNullable: true,
+        default: null,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('groups', 'staleAt');
+  }
+}

--- a/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
+++ b/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
@@ -40,6 +40,7 @@ const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
   currentRound: 0,
   totalRounds: 10,
   minMembers: 3,
+  staleAt: null,
   memberships: [],
   createdAt: new Date('2024-01-01T00:00:00Z'),
   updatedAt: new Date('2024-01-01T00:00:00Z'),
@@ -312,6 +313,31 @@ describe('GroupsService', () => {
 
       await expect(service.findAll()).rejects.toThrow('DB error');
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should filter stale groups when filter=stale', async () => {
+      const staleGroup = createMockGroup({
+        id: 'stale-1',
+        staleAt: new Date('2024-01-15'),
+      });
+      groupRepository.findAndCount!.mockResolvedValue([[staleGroup], 1]);
+
+      const result = await service.findAll(1, 10, false, 'stale');
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].staleAt).toBeTruthy();
+    });
+
+    it('should not filter when no filter is provided', async () => {
+      const groups = [
+        createMockGroup({ id: 'group-1', staleAt: null }),
+        createMockGroup({ id: 'group-2', staleAt: new Date() }),
+      ];
+      groupRepository.findAndCount!.mockResolvedValue([groups, 2]);
+
+      const result = await service.findAll(1, 10, false);
+
+      expect(result.data).toHaveLength(2);
     });
   });
 
@@ -890,6 +916,66 @@ describe('GroupsService', () => {
           userId: 'user-2',
           type: 'round_opened',
         }),
+      );
+    });
+
+    it('should clear staleAt flag when advancing round', async () => {
+      const mockGroup = createMockGroup({
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+        totalRounds: 5,
+        staleAt: new Date('2024-01-15'),
+        memberships: [
+          createMockMembership({
+            hasPaidCurrentRound: true,
+          }),
+        ],
+      });
+
+      const clearedGroup = { ...mockGroup, currentRound: 2, staleAt: null };
+      groupRepository.findOne!.mockResolvedValue(mockGroup);
+      membershipRepository.save!.mockResolvedValue({} as any);
+      groupRepository.save!.mockResolvedValue(clearedGroup as Group);
+
+      const result = await service.advanceRound(groupId, adminWallet);
+
+      expect(groupRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          staleAt: null,
+        }),
+      );
+      expect(result.staleAt).toBeNull();
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Cleared stale flag'),
+        'GroupsService',
+      );
+    });
+
+    it('should not log stale flag clearing if group was not stale', async () => {
+      const mockGroup = createMockGroup({
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+        totalRounds: 5,
+        staleAt: null,
+        memberships: [
+          createMockMembership({
+            hasPaidCurrentRound: true,
+          }),
+        ],
+      });
+
+      groupRepository.findOne!.mockResolvedValue(mockGroup);
+      membershipRepository.save!.mockResolvedValue({} as any);
+      groupRepository.save!.mockResolvedValue({
+        ...mockGroup,
+        currentRound: 2,
+      } as Group);
+
+      await service.advanceRound(groupId, adminWallet);
+
+      expect(logger.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('Cleared stale flag'),
+        'GroupsService',
       );
     });
   });

--- a/ahjoorxmr/src/groups/dto/group-response.dto.ts
+++ b/ahjoorxmr/src/groups/dto/group-response.dto.ts
@@ -84,6 +84,13 @@ export class GroupResponseDto {
   updatedAt: string;
 
   @ApiPropertyOptional({
+    description: 'Timestamp when the group was flagged as stale (ISO 8601)',
+    example: '2024-01-15T00:00:00.000Z',
+    nullable: true,
+  })
+  staleAt?: string | null;
+
+  @ApiPropertyOptional({
     description: 'List of group members (only included for GET /:id endpoint)',
     type: [MembershipResponseDto],
   })

--- a/ahjoorxmr/src/groups/entities/group.entity.ts
+++ b/ahjoorxmr/src/groups/entities/group.entity.ts
@@ -43,6 +43,9 @@ export class Group extends BaseEntity {
   @Column('int')
   minMembers: number;
 
+  @Column({ type: 'timestamp', nullable: true, default: null })
+  staleAt: Date | null;
+
   @DeleteDateColumn({ nullable: true })
   deletedAt: Date | null;
 

--- a/ahjoorxmr/src/groups/groups.controller.ts
+++ b/ahjoorxmr/src/groups/groups.controller.ts
@@ -112,6 +112,8 @@ export class GroupsController {
    *
    * @param page - Page number (default: 1)
    * @param limit - Items per page (default: 10)
+   * @param includeArchived - Include soft-deleted groups (default: false)
+   * @param filter - Optional filter: 'stale' to return only stale groups
    * @returns Paginated list of groups
    */
   @Get()
@@ -140,6 +142,13 @@ export class GroupsController {
     description: 'Include soft-deleted groups',
     example: false,
   })
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    type: String,
+    description: 'Filter groups by status (e.g., "stale" for stale groups)',
+    example: 'stale',
+  })
   @ApiResponse({
     status: 200,
     description: 'Successfully retrieved groups',
@@ -150,11 +159,13 @@ export class GroupsController {
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
     @Query('includeArchived', new DefaultValuePipe(false), ParseBoolPipe)
     includeArchived: boolean,
+    @Query('filter') filter?: string,
   ): Promise<PaginatedGroupsResponseDto> {
     const result = await this.groupsService.findAll(
       page,
       limit,
       includeArchived,
+      filter,
     );
     return {
       data: result.data.map((g) => this.toGroupResponse(g)),
@@ -471,6 +482,7 @@ export class GroupsController {
       totalRounds: group.totalRounds,
       createdAt: group.createdAt.toISOString(),
       updatedAt: group.updatedAt.toISOString(),
+      staleAt: group.staleAt ? group.staleAt.toISOString() : null,
     };
 
     if (includeMembers && group.memberships) {

--- a/ahjoorxmr/src/groups/groups.service.ts
+++ b/ahjoorxmr/src/groups/groups.service.ts
@@ -84,15 +84,17 @@ export class GroupsService {
    * @param page - Page number (1-indexed)
    * @param limit - Number of items per page
    * @param includeArchived - Whether to include soft-deleted groups
+   * @param filter - Optional filter: 'stale' to return only stale groups
    * @returns Paginated result with data, total count, page, and limit
    */
   async findAll(
     page: number = 1,
     limit: number = 10,
     includeArchived: boolean = false,
+    filter?: string,
   ): Promise<{ data: Group[]; total: number; page: number; limit: number }> {
     this.logger.log(
-      `Fetching groups page=${page} limit=${limit} includeArchived=${includeArchived}`,
+      `Fetching groups page=${page} limit=${limit} includeArchived=${includeArchived} filter=${filter}`,
       'GroupsService',
     );
 
@@ -107,6 +109,11 @@ export class GroupsService {
 
       if (includeArchived) {
         qb.withDeleted();
+      }
+
+      // Apply stale filter if requested
+      if (filter === 'stale') {
+        qb.andWhere('group.staleAt IS NOT NULL');
       }
 
       const [data, total] = await qb.getManyAndCount();
@@ -469,6 +476,15 @@ export class GroupsService {
     }
 
     group.currentRound += 1;
+
+    // Clear stale flag when group is updated
+    if (group.staleAt) {
+      group.staleAt = null;
+      this.logger.log(
+        `Cleared stale flag for group ${groupId} during round advance`,
+        'GroupsService',
+      );
+    }
 
     if (group.currentRound > group.totalRounds) {
       group.status = GroupStatus.COMPLETED;

--- a/ahjoorxmr/src/notification/notification-type.enum.ts
+++ b/ahjoorxmr/src/notification/notification-type.enum.ts
@@ -5,4 +5,5 @@ export enum NotificationType {
   MEMBER_JOINED = 'member_joined',
   MEMBER_LEFT = 'member_left',
   MEMBER_REMOVED = 'member_removed',
+  SYSTEM_ALERT = 'system_alert',
 }

--- a/ahjoorxmr/src/scheduler/scheduler.module.ts
+++ b/ahjoorxmr/src/scheduler/scheduler.module.ts
@@ -5,11 +5,13 @@ import { SchedulerService } from './scheduler.service';
 import { AuditLogService } from './services/audit-log.service';
 import { ContributionSummaryService } from './services/contribution-summary.service';
 import { GroupStatusService } from './services/group-status.service';
+import { StaleGroupDetectionService } from './services/stale-group-detection.service';
 import { DistributedLockService } from './services/distributed-lock.service';
 import { AuditLog } from './entities/audit-log.entity';
 import { Contribution } from '../contributions/entities/contribution.entity';
 import { Group } from '../groups/entities/group.entity';
 import { Membership } from '../memberships/entities/membership.entity';
+import { NotificationsService } from '../notification/notifications.service';
 
 @Module({
   imports: [
@@ -21,7 +23,9 @@ import { Membership } from '../memberships/entities/membership.entity';
     AuditLogService,
     ContributionSummaryService,
     GroupStatusService,
+    StaleGroupDetectionService,
     DistributedLockService,
+    NotificationsService,
   ],
   exports: [AuditLogService],
 })

--- a/ahjoorxmr/src/scheduler/scheduler.service.ts
+++ b/ahjoorxmr/src/scheduler/scheduler.service.ts
@@ -4,6 +4,7 @@ import { DistributedLockService } from './services/distributed-lock.service';
 import { AuditLogService } from './services/audit-log.service';
 import { ContributionSummaryService } from './services/contribution-summary.service';
 import { GroupStatusService } from './services/group-status.service';
+import { StaleGroupDetectionService } from './services/stale-group-detection.service';
 
 @Injectable()
 export class SchedulerService {
@@ -16,6 +17,7 @@ export class SchedulerService {
     private readonly auditLogService: AuditLogService,
     private readonly contributionSummaryService: ContributionSummaryService,
     private readonly groupStatusService: GroupStatusService,
+    private readonly staleGroupDetectionService: StaleGroupDetectionService,
   ) {}
 
   /**
@@ -127,6 +129,41 @@ export class SchedulerService {
     if (result) {
       this.logger.log(
         `Task ${taskName} completed successfully in ${duration}ms. Updated ${result.updatedCount} groups, found ${result.inactiveGroupCount} inactive groups.`,
+      );
+    } else {
+      this.logger.warn(`Task ${taskName} was skipped (lock not acquired)`);
+    }
+  }
+
+  /**
+   * Daily task: Detect and flag stale groups (runs at 3 AM)
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM, {
+    name: 'detect-stale-groups',
+  })
+  async handleStaleGroupDetection(): Promise<void> {
+    const taskName = 'detect-stale-groups';
+    const startTime = Date.now();
+
+    this.logger.log(`Starting task: ${taskName}`);
+
+    const result = await this.lockService.withLock(
+      taskName,
+      async () => {
+        return await this.executeWithRetry(async () => {
+          const flaggedCount =
+            await this.staleGroupDetectionService.detectAndFlagStaleGroups();
+          return { flaggedCount };
+        }, taskName);
+      },
+      600, // 10 minutes lock TTL
+    );
+
+    const duration = Date.now() - startTime;
+
+    if (result) {
+      this.logger.log(
+        `Task ${taskName} completed successfully in ${duration}ms. Flagged ${result.flaggedCount} stale group(s).`,
       );
     } else {
       this.logger.warn(`Task ${taskName} was skipped (lock not acquired)`);

--- a/ahjoorxmr/src/scheduler/services/__tests__/stale-group-detection.service.spec.ts
+++ b/ahjoorxmr/src/scheduler/services/__tests__/stale-group-detection.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { StaleGroupDetectionService } from '../stale-group-detection.service';
+import { Group } from '../../../groups/entities/group.entity';
+import { GroupStatus } from '../../../groups/entities/group-status.enum';
+import { NotificationsService } from '../../../notification/notifications.service';
+import { NotificationType } from '../../../notification/notification-type.enum';
+
+describe('StaleGroupDetectionService', () => {
+  let service: StaleGroupDetectionService;
+  let groupRepository: jest.Mocked<Repository<Group>>;
+  let notificationsService: jest.Mocked<NotificationsService>;
+  let configService: jest.Mocked<ConfigService>;
+
+  const mockGroup = (overrides: Partial<Group> = {}): Group => ({
+    id: 'group-1',
+    name: 'Test Group',
+    contractAddress: 'CTEST123',
+    adminWallet: 'GADMIN123',
+    contributionAmount: '100',
+    token: 'USDC',
+    roundDuration: 2592000,
+    status: GroupStatus.ACTIVE,
+    currentRound: 1,
+    totalRounds: 10,
+    minMembers: 3,
+    staleAt: null,
+    deletedAt: null,
+    memberships: [],
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StaleGroupDetectionService,
+        {
+          provide: getRepositoryToken(Group),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            notify: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'MAX_STALE_GROUP_DAYS') return 7;
+              return defaultValue;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<StaleGroupDetectionService>(
+      StaleGroupDetectionService,
+    );
+    groupRepository = module.get(getRepositoryToken(Group));
+    notificationsService = module.get(NotificationsService);
+    configService = module.get(ConfigService);
+  });
+
+  describe('detectAndFlagStaleGroups', () => {
+    it('should detect and flag stale groups', async () => {
+      const staleGroup = mockGroup({
+        id: 'stale-group-1',
+        name: 'Stale Group',
+        updatedAt: new Date('2024-01-01'),
+        staleAt: null,
+      });
+
+      groupRepository.find.mockResolvedValue([staleGroup]);
+      groupRepository.save.mockResolvedValue({
+        ...staleGroup,
+        staleAt: new Date(),
+      });
+
+      const result = await service.detectAndFlagStaleGroups();
+
+      expect(result).toBe(1);
+      expect(groupRepository.find).toHaveBeenCalledWith({
+        where: {
+          status: GroupStatus.ACTIVE,
+          updatedAt: expect.any(Date),
+          staleAt: null,
+        },
+        relations: ['memberships'],
+      });
+      expect(groupRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'stale-group-1',
+          staleAt: expect.any(Date),
+        }),
+      );
+      expect(notificationsService.notify).toHaveBeenCalledWith({
+        userId: 'GADMIN123',
+        type: NotificationType.SYSTEM_ALERT,
+        title: 'Stale Group Detected',
+        body: expect.stringContaining('Stale Group'),
+        metadata: expect.objectContaining({
+          groupId: 'stale-group-1',
+          groupName: 'Stale Group',
+          staleDays: 7,
+        }),
+      });
+    });
+
+    it('should handle multiple stale groups', async () => {
+      const staleGroups = [
+        mockGroup({ id: 'group-1', name: 'Group 1' }),
+        mockGroup({ id: 'group-2', name: 'Group 2' }),
+        mockGroup({ id: 'group-3', name: 'Group 3' }),
+      ];
+
+      groupRepository.find.mockResolvedValue(staleGroups);
+      groupRepository.save.mockImplementation((group) =>
+        Promise.resolve({ ...group, staleAt: new Date() }),
+      );
+
+      const result = await service.detectAndFlagStaleGroups();
+
+      expect(result).toBe(3);
+      expect(groupRepository.save).toHaveBeenCalledTimes(3);
+      expect(notificationsService.notify).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return 0 when no stale groups found', async () => {
+      groupRepository.find.mockResolvedValue([]);
+
+      const result = await service.detectAndFlagStaleGroups();
+
+      expect(result).toBe(0);
+      expect(groupRepository.save).not.toHaveBeenCalled();
+      expect(notificationsService.notify).not.toHaveBeenCalled();
+    });
+
+    it('should skip groups already flagged as stale', async () => {
+      const alreadyStaleGroup = mockGroup({
+        staleAt: new Date('2024-01-10'),
+      });
+
+      groupRepository.find.mockResolvedValue([alreadyStaleGroup]);
+
+      const result = await service.detectAndFlagStaleGroups();
+
+      // The query should filter out already stale groups
+      expect(groupRepository.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          staleAt: null,
+        }),
+        relations: ['memberships'],
+      });
+    });
+
+    it('should continue processing if one group fails', async () => {
+      const group1 = mockGroup({ id: 'group-1', name: 'Group 1' });
+      const group2 = mockGroup({ id: 'group-2', name: 'Group 2' });
+
+      groupRepository.find.mockResolvedValue([group1, group2]);
+      groupRepository.save
+        .mockRejectedValueOnce(new Error('Database error'))
+        .mockResolvedValueOnce({ ...group2, staleAt: new Date() });
+
+      const result = await service.detectAndFlagStaleGroups();
+
+      expect(result).toBe(1);
+      expect(groupRepository.save).toHaveBeenCalledTimes(2);
+      expect(notificationsService.notify).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use configured MAX_STALE_GROUP_DAYS', async () => {
+      configService.get.mockReturnValue(14);
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          StaleGroupDetectionService,
+          {
+            provide: getRepositoryToken(Group),
+            useValue: groupRepository,
+          },
+          {
+            provide: NotificationsService,
+            useValue: notificationsService,
+          },
+          {
+            provide: ConfigService,
+            useValue: configService,
+          },
+        ],
+      }).compile();
+
+      const customService = module.get<StaleGroupDetectionService>(
+        StaleGroupDetectionService,
+      );
+
+      groupRepository.find.mockResolvedValue([]);
+
+      await customService.detectAndFlagStaleGroups();
+
+      expect(configService.get).toHaveBeenCalledWith('MAX_STALE_GROUP_DAYS', 7);
+    });
+  });
+
+  describe('clearStaleFlag', () => {
+    it('should clear stale flag for a group', async () => {
+      const staleGroup = mockGroup({
+        id: 'group-1',
+        staleAt: new Date('2024-01-10'),
+      });
+
+      groupRepository.findOne.mockResolvedValue(staleGroup);
+      groupRepository.save.mockResolvedValue({
+        ...staleGroup,
+        staleAt: null,
+      });
+
+      await service.clearStaleFlag('group-1');
+
+      expect(groupRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'group-1' },
+      });
+      expect(groupRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'group-1',
+          staleAt: null,
+        }),
+      );
+    });
+
+    it('should do nothing if group not found', async () => {
+      groupRepository.findOne.mockResolvedValue(null);
+
+      await service.clearStaleFlag('non-existent');
+
+      expect(groupRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if group is not stale', async () => {
+      const nonStaleGroup = mockGroup({
+        staleAt: null,
+      });
+
+      groupRepository.findOne.mockResolvedValue(nonStaleGroup);
+
+      await service.clearStaleFlag('group-1');
+
+      expect(groupRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async () => {
+      groupRepository.findOne.mockRejectedValue(new Error('Database error'));
+
+      await expect(service.clearStaleFlag('group-1')).resolves.not.toThrow();
+    });
+  });
+});

--- a/ahjoorxmr/src/scheduler/services/stale-group-detection.service.ts
+++ b/ahjoorxmr/src/scheduler/services/stale-group-detection.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Group } from '../../groups/entities/group.entity';
+import { GroupStatus } from '../../groups/entities/group-status.enum';
+import { NotificationsService } from '../../notification/notifications.service';
+import { NotificationType } from '../../notification/notification-type.enum';
+
+/**
+ * Service responsible for detecting and flagging stale groups.
+ * A group is considered stale if it's ACTIVE but hasn't been updated
+ * within the configured MAX_STALE_GROUP_DAYS threshold.
+ */
+@Injectable()
+export class StaleGroupDetectionService {
+  private readonly logger = new Logger(StaleGroupDetectionService.name);
+  private readonly maxStaleDays: number;
+
+  constructor(
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
+    private readonly notificationsService: NotificationsService,
+    private readonly configService: ConfigService,
+  ) {
+    this.maxStaleDays = this.configService.get<number>(
+      'MAX_STALE_GROUP_DAYS',
+      7,
+    );
+  }
+
+  /**
+   * Detects and flags stale groups.
+   * Returns the number of groups flagged as stale.
+   */
+  async detectAndFlagStaleGroups(): Promise<number> {
+    this.logger.log(
+      `Starting stale group detection (threshold: ${this.maxStaleDays} days)`,
+    );
+
+    const staleThreshold = new Date();
+    staleThreshold.setDate(staleThreshold.getDate() - this.maxStaleDays);
+
+    try {
+      // Find ACTIVE groups that haven't been updated within the threshold
+      // and are not already flagged as stale
+      const staleGroups = await this.groupRepository.find({
+        where: {
+          status: GroupStatus.ACTIVE,
+          updatedAt: LessThan(staleThreshold),
+          staleAt: null,
+        },
+        relations: ['memberships'],
+      });
+
+      this.logger.log(`Found ${staleGroups.length} stale group(s)`);
+
+      let flaggedCount = 0;
+
+      for (const group of staleGroups) {
+        try {
+          // Flag the group as stale
+          group.staleAt = new Date();
+          await this.groupRepository.save(group);
+
+          // Send SYSTEM_ALERT notification to the admin
+          await this.notificationsService.notify({
+            userId: group.adminWallet,
+            type: NotificationType.SYSTEM_ALERT,
+            title: 'Stale Group Detected',
+            body: `Group "${group.name}" has not been updated in ${this.maxStaleDays} days. Please review and take action.`,
+            metadata: {
+              groupId: group.id,
+              groupName: group.name,
+              lastUpdated: group.updatedAt.toISOString(),
+              staleDays: this.maxStaleDays,
+            },
+          });
+
+          this.logger.log(
+            `Flagged group ${group.id} (${group.name}) as stale and notified admin ${group.adminWallet}`,
+          );
+
+          flaggedCount++;
+        } catch (error) {
+          this.logger.error(
+            `Failed to flag group ${group.id} as stale: ${error.message}`,
+            error.stack,
+          );
+        }
+      }
+
+      this.logger.log(
+        `Stale group detection completed. Flagged ${flaggedCount} group(s)`,
+      );
+
+      return flaggedCount;
+    } catch (error) {
+      this.logger.error(
+        `Failed to detect stale groups: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Clears the staleAt flag for a specific group.
+   * Called when a group is updated (e.g., round advanced or completed).
+   */
+  async clearStaleFlag(groupId: string): Promise<void> {
+    try {
+      const group = await this.groupRepository.findOne({
+        where: { id: groupId },
+      });
+
+      if (group && group.staleAt) {
+        group.staleAt = null;
+        await this.groupRepository.save(group);
+        this.logger.log(`Cleared stale flag for group ${groupId}`);
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to clear stale flag for group ${groupId}: ${error.message}`,
+        error.stack,
+      );
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a **Stale Group Detection System** that automatically identifies inactive groups, flags them, and notifies administrators.

The system improves operational visibility by ensuring inactive groups are surfaced and handled proactively.

---

## ✨ Key Features

### 🗄️ Group Entity Update

- Added new field:
  - `staleAt: Date | null`
- Tracks when a group is marked as stale

---

### ⚙️ Configurable Threshold

- Added environment variable:
  - `MAX_STALE_GROUP_DAYS=7`
- Defines the inactivity period before a group is flagged as stale

---

### 🧠 Stale Detection Service

- Created `StaleGroupDetectionService`

#### Core Methods:
- `detectAndFlagStaleGroups()`
  - Identifies ACTIVE groups not updated within threshold  
  - Flags them by setting `staleAt`  
  - Sends notifications to admins  

- `clearStaleFlag()`
  - Removes `staleAt` when group activity resumes  

---

### 🔔 Notification System

- Added new notification type:
  - `SYSTEM_ALERT`
- Automatically notifies **group admins** when a group becomes stale

---

### ⏰ Scheduled Execution

- Integrated into `SchedulerService`
- Added **daily cron job (3 AM)**:
  - Automatically runs stale group detection

---

closes #101 
