### PR TITLE
feat:  implement round Number Validation Against Active Group Round

### DIFF
--- a/ahjoorxmr/src/contributions/__tests__/contributions.service.spec.ts
+++ b/ahjoorxmr/src/contributions/__tests__/contributions.service.spec.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { ContributionsService } from '../contributions.service';
 import { Contribution } from '../entities/contribution.entity';
 import { Group } from '../../groups/entities/group.entity';
+import { GroupStatus } from '../../groups/entities/group-status.enum';
 import { StellarService } from '../../stellar/stellar.service';
 import { WinstonLogger } from '../../common/logger/winston.logger';
 import { CreateContributionDto } from '../dto/create-contribution.dto';
@@ -95,7 +96,11 @@ describe('ContributionsService', () => {
   describe('createContribution', () => {
     it('should create a contribution when verification is disabled', async () => {
       configService.get!.mockReturnValue(false); // VERIFY_CONTRIBUTIONS = false
-      groupRepository.findOne!.mockResolvedValue({ id: 'group-1' });
+      groupRepository.findOne!.mockResolvedValue({
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+      });
       contributionRepository.findOne!.mockResolvedValue(null); // No duplicate hash
       contributionRepository.create!.mockReturnValue(mockContribution);
       contributionRepository.save!.mockResolvedValue(mockContribution);
@@ -110,7 +115,11 @@ describe('ContributionsService', () => {
     it('should create a contribution when verification is enabled and successful', async () => {
       configService.get!.mockReturnValue(true); // VERIFY_CONTRIBUTIONS = true
       stellarService.verifyContribution!.mockResolvedValue(true);
-      groupRepository.findOne!.mockResolvedValue({ id: 'group-1' });
+      groupRepository.findOne!.mockResolvedValue({
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+      });
       contributionRepository.findOne!.mockResolvedValue(null);
       contributionRepository.create!.mockReturnValue(mockContribution);
       contributionRepository.save!.mockResolvedValue(mockContribution);
@@ -125,7 +134,11 @@ describe('ContributionsService', () => {
     it('should throw BadRequestException when verification fails', async () => {
       configService.get!.mockReturnValue(true);
       stellarService.verifyContribution!.mockResolvedValue(false);
-      groupRepository.findOne!.mockResolvedValue({ id: 'group-1' });
+      groupRepository.findOne!.mockResolvedValue({
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+      });
 
       await expect(
         service.createContribution(createContributionDto),
@@ -136,7 +149,11 @@ describe('ContributionsService', () => {
     it('should throw ConflictException when transaction hash already exists', async () => {
       configService.get!.mockReturnValue(true);
       stellarService.verifyContribution!.mockResolvedValue(true);
-      groupRepository.findOne!.mockResolvedValue({ id: 'group-1' });
+      groupRepository.findOne!.mockResolvedValue({
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+      });
       contributionRepository.findOne!.mockResolvedValue(mockContribution);
 
       await expect(
@@ -156,6 +173,8 @@ describe('ContributionsService', () => {
     it('should use group contractAddress when available', async () => {
       const groupWithContract = {
         id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
         contractAddress:
           'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
       };
@@ -179,6 +198,8 @@ describe('ContributionsService', () => {
     it('should fall back to global contract address when group contractAddress is null', async () => {
       const groupWithoutContract = {
         id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
         contractAddress: null,
       };
       configService.get!.mockReturnValue(true);
@@ -205,6 +226,8 @@ describe('ContributionsService', () => {
     it('should throw BadRequestException when verification fails against group contract', async () => {
       const groupWithContract = {
         id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
         contractAddress:
           'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
       };
@@ -221,6 +244,8 @@ describe('ContributionsService', () => {
     it('should throw BadRequestException when verification fails against global contract', async () => {
       const groupWithoutContract = {
         id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
         contractAddress: null,
       };
       configService.get!.mockReturnValue(true);
@@ -231,6 +256,162 @@ describe('ContributionsService', () => {
         service.createContribution(createContributionDto),
       ).rejects.toThrow(BadRequestException);
       expect(contributionRepository.save).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Round Number Validation Tests
+    // -------------------------------------------------------------------------
+
+    it('should throw BadRequestException when contribution is for a future round', async () => {
+      const futureRoundDto: CreateContributionDto = {
+        ...createContributionDto,
+        roundNumber: 5, // Future round
+      };
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1, // Current round is 1
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+
+      await expect(service.createContribution(futureRoundDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.createContribution(futureRoundDto)).rejects.toThrow(
+        'Contributions can only be made for the current round',
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Round number mismatch'),
+        'ContributionsService',
+      );
+      expect(contributionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when contribution is for a past round', async () => {
+      const pastRoundDto: CreateContributionDto = {
+        ...createContributionDto,
+        roundNumber: 1, // Past round
+      };
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 5, // Current round is 5
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+
+      await expect(service.createContribution(pastRoundDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.createContribution(pastRoundDto)).rejects.toThrow(
+        'Contributions can only be made for the current round',
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Round number mismatch'),
+        'ContributionsService',
+      );
+      expect(contributionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should succeed when roundNumber matches group currentRound', async () => {
+      const correctRoundDto: CreateContributionDto = {
+        ...createContributionDto,
+        roundNumber: 3,
+      };
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 3, // Matches the DTO
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+      contributionRepository.findOne!.mockResolvedValue(null);
+      contributionRepository.create!.mockReturnValue({
+        ...mockContribution,
+        roundNumber: 3,
+      });
+      contributionRepository.save!.mockResolvedValue({
+        ...mockContribution,
+        roundNumber: 3,
+      });
+
+      const result = await service.createContribution(correctRoundDto);
+
+      expect(result.roundNumber).toBe(3);
+      expect(contributionRepository.save).toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Group Status Validation Tests
+    // -------------------------------------------------------------------------
+
+    it('should throw BadRequestException when group status is PENDING', async () => {
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.PENDING,
+        currentRound: 0,
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+
+      await expect(
+        service.createContribution(createContributionDto),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.createContribution(createContributionDto),
+      ).rejects.toThrow('Contributions can only be made to ACTIVE groups');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot create contribution'),
+        'ContributionsService',
+      );
+      expect(contributionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when group status is COMPLETED', async () => {
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.COMPLETED,
+        currentRound: 10,
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+
+      await expect(
+        service.createContribution(createContributionDto),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.createContribution(createContributionDto),
+      ).rejects.toThrow('Contributions can only be made to ACTIVE groups');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot create contribution'),
+        'ContributionsService',
+      );
+      expect(contributionRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should succeed when group status is ACTIVE and round matches', async () => {
+      const group = {
+        id: 'group-1',
+        status: GroupStatus.ACTIVE,
+        currentRound: 1,
+      };
+
+      configService.get!.mockReturnValue(false);
+      groupRepository.findOne!.mockResolvedValue(group);
+      contributionRepository.findOne!.mockResolvedValue(null);
+      contributionRepository.create!.mockReturnValue(mockContribution);
+      contributionRepository.save!.mockResolvedValue(mockContribution);
+
+      const result = await service.createContribution(createContributionDto);
+
+      expect(result).toEqual(mockContribution);
+      expect(contributionRepository.save).toHaveBeenCalled();
     });
   });
 

--- a/ahjoorxmr/src/contributions/contributions.service.ts
+++ b/ahjoorxmr/src/contributions/contributions.service.ts
@@ -7,6 +7,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { Contribution } from './entities/contribution.entity';
 import { Group } from '../groups/entities/group.entity';
+import { GroupStatus } from '../groups/entities/group-status.enum';
 import { WinstonLogger } from '../common/logger/winston.logger';
 import { CreateContributionDto } from './dto/create-contribution.dto';
 import { StellarService } from '../stellar/stellar.service';
@@ -53,17 +54,19 @@ export class ContributionsService {
   /**
    * Creates a new contribution record.
    * Validates that the group and user exist, checks for duplicate transaction hash,
+   * validates round number matches current round, validates group is ACTIVE,
    * and creates the contribution record.
    *
    * @param createContributionDto - The contribution data
    * @returns The created Contribution entity
-   * @throws BadRequestException if the group or user doesn't exist
+   * @throws BadRequestException if the group or user doesn't exist, round number is invalid, or group is not ACTIVE
    * @throws ConflictException if the transaction hash already exists
    */
   async createContribution(
     createContributionDto: CreateContributionDto,
   ): Promise<Contribution> {
-    const { groupId, userId, transactionHash } = createContributionDto;
+    const { groupId, userId, transactionHash, roundNumber } =
+      createContributionDto;
 
     this.logger.log(
       `Creating contribution for user ${userId} in group ${groupId} with transaction hash ${transactionHash}`,
@@ -73,6 +76,28 @@ export class ContributionsService {
     try {
       // Validate group exists and fetch it
       const group = await this.validateGroupExists(groupId);
+
+      // Validate group status is ACTIVE
+      if (group.status !== GroupStatus.ACTIVE) {
+        this.logger.warn(
+          `Cannot create contribution for group ${groupId} with status ${group.status}`,
+          'ContributionsService',
+        );
+        throw new BadRequestException(
+          'Contributions can only be made to ACTIVE groups',
+        );
+      }
+
+      // Validate round number matches current round
+      if (roundNumber !== group.currentRound) {
+        this.logger.warn(
+          `Round number mismatch for group ${groupId}: provided ${roundNumber}, current ${group.currentRound}`,
+          'ContributionsService',
+        );
+        throw new BadRequestException(
+          'Contributions can only be made for the current round',
+        );
+      }
 
       // Verify contribution if enabled
       const shouldVerify = this.configService.get<boolean>(


### PR DESCRIPTION


This PR introduces **round number and group status validation** in the `ContributionsService` to prevent invalid contributions.

The system now enforces that contributions can only be made:
- To **ACTIVE groups**
- For the **current round only**

This ensures data integrity, prevents misuse, and aligns contributions with the correct lifecycle state.

---

## ✨ Key Changes

### 🧩 ContributionsService अपडेट (`contributions.service.ts`)

#### ✅ New Validations

- **Group Status Validation**
  - Ensures:
    - `group.status === ACTIVE`
  - Rejects:
    - `PENDING`
    - `COMPLETED`

- **Round Validation**
  - Ensures:
    - `roundNumber === group.currentRound`
  - Rejects:
    - Past rounds (`< currentRound`)
    - Future rounds (`> currentRound`)

---

### ❌ Error Handling

- Throws `BadRequestException` with clear messages:

  - **Invalid Status**
    ```
    Contributions can only be made to ACTIVE groups
    ```

  - **Invalid Round**
    ```
    Contributions can only be made for the current round
    ```

---

### 📊 Logging

- Added detailed logging for:
  - Validation failures  
  - Invalid round attempts  
  - Invalid group status  

- Improves debugging and monitoring in production

---

### 🧪 Unit Tests (`contributions.service.spec.ts`)

Added comprehensive test coverage:

#### Round Validation Tests
- ❌ Reject future round (`roundNumber > currentRound`)
- ❌ Reject past round (`roundNumber < currentRound`)
- ✅ Accept correct round (`roundNumber === currentRound`)

#### Group Status Tests
- ❌ Reject `PENDING` group
- ❌ Reject `COMPLETED` group
- ✅ Accept `ACTIVE` group

---

### 🔄 Updated Existing Tests

- Updated all existing tests to include:
  - `group.status`
  - `group.currentRound`

- Ensures compatibility with new validation logic

---

## 🔁 Validation Flow

Validation now occurs in the following order:

1. Group existence check (existing)  
2. **Group status validation (new)**  
3. **Round number validation (new)**  
4. Transaction verification (existing)  


---

closes #100 

