### PR TITLE
feat(memberships): enforce maxMembers cap 

### DIFF
--- a/ahjoorxmr/migrations/1740600000000-AddMaxMembersToGroups.ts
+++ b/ahjoorxmr/migrations/1740600000000-AddMaxMembersToGroups.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddMaxMembersToGroups1740600000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'groups',
+      new TableColumn({
+        name: 'maxMembers',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+
+    // Back-fill existing rows: maxMembers = totalRounds
+    await queryRunner.query(
+      `UPDATE "groups" SET "maxMembers" = "totalRounds" WHERE "maxMembers" IS NULL`,
+    );
+
+    await queryRunner.changeColumn(
+      'groups',
+      'maxMembers',
+      new TableColumn({
+        name: 'maxMembers',
+        type: 'int',
+        isNullable: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('groups', 'maxMembers');
+  }
+}

--- a/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
+++ b/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
@@ -40,6 +40,7 @@ const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
   currentRound: 0,
   totalRounds: 10,
   minMembers: 3,
+  maxMembers: 10,
   staleAt: null,
   memberships: [],
   createdAt: new Date('2024-01-01T00:00:00Z'),
@@ -182,6 +183,7 @@ describe('GroupsService', () => {
       token: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
       roundDuration: 2592000,
       totalRounds: 12,
+      minMembers: 3,
     };
 
     it('should create and return a PENDING group', async () => {
@@ -189,6 +191,7 @@ describe('GroupsService', () => {
         name: dto.name,
         contributionAmount: dto.contributionAmount,
         totalRounds: dto.totalRounds,
+        maxMembers: dto.totalRounds,
       });
 
       groupRepository.create!.mockReturnValue(mockGroup);
@@ -202,6 +205,7 @@ describe('GroupsService', () => {
           currentRound: 0,
           adminWallet: ADMIN_WALLET,
           contractAddress: null,
+          maxMembers: dto.totalRounds,
         }),
       );
       expect(groupRepository.save).toHaveBeenCalledWith(mockGroup);
@@ -243,6 +247,40 @@ describe('GroupsService', () => {
       await service.createGroup(dto, ADMIN_WALLET);
 
       expect(logger.log).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw BadRequestException when maxMembers != totalRounds', async () => {
+      const invalidDto = { ...dto, totalRounds: 12, maxMembers: 10 };
+
+      await expect(service.createGroup(invalidDto, ADMIN_WALLET)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.createGroup(invalidDto, ADMIN_WALLET)).rejects.toThrow(
+        'maxMembers must equal totalRounds',
+      );
+    });
+
+    it('should throw BadRequestException when minMembers > maxMembers', async () => {
+      const invalidDto = { ...dto, totalRounds: 5, minMembers: 8 };
+
+      await expect(service.createGroup(invalidDto, ADMIN_WALLET)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.createGroup(invalidDto, ADMIN_WALLET)).rejects.toThrow(
+        'minMembers must be less than or equal to maxMembers',
+      );
+    });
+
+    it('should default maxMembers to totalRounds when not provided', async () => {
+      const mockGroup = createMockGroup({ totalRounds: 12, maxMembers: 12 });
+      groupRepository.create!.mockReturnValue(mockGroup);
+      groupRepository.save!.mockResolvedValue(mockGroup);
+
+      await service.createGroup(dto, ADMIN_WALLET);
+
+      expect(groupRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ maxMembers: dto.totalRounds }),
+      );
     });
 
     it('should propagate unexpected errors', async () => {

--- a/ahjoorxmr/src/groups/dto/create-group.dto.ts
+++ b/ahjoorxmr/src/groups/dto/create-group.dto.ts
@@ -71,6 +71,26 @@ export class CreateGroupDto {
   @Min(1)
   totalRounds: number;
 
+  @ApiProperty({
+    description: 'Minimum number of members required to activate the group',
+    example: 3,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  minMembers: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Maximum number of members allowed (must equal totalRounds; defaults to totalRounds)',
+    example: 12,
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxMembers?: number;
+
   @ApiPropertyOptional({
     description:
       'On-chain contract address (optional at creation time, assigned after deployment)',

--- a/ahjoorxmr/src/groups/dto/group-response.dto.ts
+++ b/ahjoorxmr/src/groups/dto/group-response.dto.ts
@@ -72,6 +72,12 @@ export class GroupResponseDto {
   totalRounds: number;
 
   @ApiProperty({
+    description: 'Maximum number of members allowed in the group',
+    example: 12,
+  })
+  maxMembers: number;
+
+  @ApiProperty({
     description: 'Group creation timestamp (ISO 8601)',
     example: '2024-01-01T00:00:00.000Z',
   })

--- a/ahjoorxmr/src/groups/entities/group.entity.ts
+++ b/ahjoorxmr/src/groups/entities/group.entity.ts
@@ -43,6 +43,9 @@ export class Group extends BaseEntity {
   @Column('int')
   minMembers: number;
 
+  @Column('int')
+  maxMembers: number;
+
   @Column({ type: 'timestamp', nullable: true, default: null })
   staleAt: Date | null;
 

--- a/ahjoorxmr/src/groups/groups.service.ts
+++ b/ahjoorxmr/src/groups/groups.service.ts
@@ -51,8 +51,23 @@ export class GroupsService {
     );
 
     try {
+      const maxMembers = createGroupDto.maxMembers ?? createGroupDto.totalRounds;
+
+      if (maxMembers !== createGroupDto.totalRounds) {
+        throw new BadRequestException(
+          'maxMembers must equal totalRounds',
+        );
+      }
+
+      if (createGroupDto.minMembers > maxMembers) {
+        throw new BadRequestException(
+          'minMembers must be less than or equal to maxMembers',
+        );
+      }
+
       const group = this.groupRepository.create({
         ...createGroupDto,
+        maxMembers,
         adminWallet,
         status: GroupStatus.PENDING,
         currentRound: 0,

--- a/ahjoorxmr/src/memberships/__tests__/memberships.service.spec.ts
+++ b/ahjoorxmr/src/memberships/__tests__/memberships.service.spec.ts
@@ -48,6 +48,8 @@ const createMockGroup = (overrides?: Partial<Group>): Group => {
     name: 'Test Group',
     contributionAmount: '100',
     status: GroupStatus.PENDING,
+    totalRounds: 5,
+    maxMembers: 5,
   };
 
   return { ...defaultGroup, ...overrides } as Group;
@@ -68,6 +70,7 @@ const createMockRepository = <T = any>(): MockRepository<T> => ({
   create: jest.fn(),
   save: jest.fn(),
   remove: jest.fn(),
+  count: jest.fn(),
   createQueryBuilder: jest.fn(),
 });
 
@@ -270,8 +273,75 @@ describe('MembershipsService', () => {
 
   // Placeholder for addMember tests
   describe('addMember', () => {
+    const groupId = '123e4567-e89b-12d3-a456-426614174001';
+    const dto = {
+      userId: '123e4567-e89b-12d3-a456-426614174002',
+      walletAddress: '0xabc',
+    };
+
     it('should be defined', () => {
       expect(service.addMember).toBeDefined();
+    });
+
+    it('should throw BadRequestException when group is at maxMembers cap', async () => {
+      const group = createMockGroup({ maxMembers: 3 });
+      groupRepository.findOne!.mockResolvedValue(group);
+      membershipRepository.count!.mockResolvedValue(3);
+
+      await expect(service.addMember(groupId, dto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.addMember(groupId, dto)).rejects.toThrow(
+        'maximum member capacity of 3',
+      );
+    });
+
+    it('should throw BadRequestException when group exceeds maxMembers cap', async () => {
+      const group = createMockGroup({ maxMembers: 3 });
+      groupRepository.findOne!.mockResolvedValue(group);
+      membershipRepository.count!.mockResolvedValue(4);
+
+      await expect(service.addMember(groupId, dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should add member successfully when below maxMembers cap', async () => {
+      const group = createMockGroup({ maxMembers: 3 });
+      const membership = createMockMembership();
+      groupRepository.findOne!.mockResolvedValue(group);
+      membershipRepository.count!.mockResolvedValue(2);
+      membershipRepository.findOne!.mockResolvedValue(null);
+      membershipRepository.createQueryBuilder!.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ maxOrder: null }),
+      });
+      membershipRepository.create!.mockReturnValue(membership);
+      membershipRepository.save!.mockResolvedValue(membership);
+
+      const result = await service.addMember(groupId, dto);
+
+      expect(result).toEqual(membership);
+    });
+
+    it('should add member successfully when exactly one below cap (boundary)', async () => {
+      const group = createMockGroup({ maxMembers: 5 });
+      const membership = createMockMembership();
+      groupRepository.findOne!.mockResolvedValue(group);
+      membershipRepository.count!.mockResolvedValue(4);
+      membershipRepository.findOne!.mockResolvedValue(null);
+      membershipRepository.createQueryBuilder!.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ maxOrder: 3 }),
+      });
+      membershipRepository.create!.mockReturnValue(membership);
+      membershipRepository.save!.mockResolvedValue(membership);
+
+      const result = await service.addMember(groupId, dto);
+
+      expect(result).toEqual(membership);
     });
   });
 

--- a/ahjoorxmr/src/memberships/memberships.service.ts
+++ b/ahjoorxmr/src/memberships/memberships.service.ts
@@ -39,7 +39,7 @@ export class MembershipsService {
    * @throws BadRequestException if the group is already active
    * @private
    */
-  private async validateGroupNotActive(groupId: string): Promise<void> {
+  private async validateGroupNotActive(groupId: string): Promise<Group> {
     const group = await this.groupRepository.findOne({
       where: { id: groupId },
     });
@@ -58,6 +58,8 @@ export class MembershipsService {
         'Cannot modify memberships for an active group',
       );
     }
+
+    return group;
   }
 
   /**
@@ -103,7 +105,22 @@ export class MembershipsService {
 
     try {
       // Validate group exists and is not active
-      await this.validateGroupNotActive(groupId);
+      const group = await this.validateGroupNotActive(groupId);
+
+      // Enforce maxMembers cap
+      const memberCount = await this.membershipRepository.count({
+        where: { groupId },
+      });
+
+      if (memberCount >= group.maxMembers) {
+        this.logger.warn(
+          `Group ${groupId} is at capacity (${memberCount}/${group.maxMembers})`,
+          'MembershipsService',
+        );
+        throw new BadRequestException(
+          `Group has reached its maximum member capacity of ${group.maxMembers}`,
+        );
+      }
 
       // Check for duplicate membership
       const existingMembership = await this.membershipRepository.findOne({


### PR DESCRIPTION

Enforces the ROSCA invariant that a group cannot have more members than its totalRounds count. A group can no longer silently grow beyond capacity.

Changes
Entity & DTO

Added maxMembers: number column to the Group entity

Added minMembers and optional maxMembers to CreateGroupDto (defaults to totalRounds when omitted)

Exposed maxMembers in GroupResponseDto for Swagger

Validation — GroupsService.createGroup

Throws 400 Bad Request if maxMembers !== totalRounds

Throws 400 Bad Request if minMembers > maxMembers

Defaults maxMembers to totalRounds when not provided

Cap enforcement — MembershipsService.addMember

Counts current members before inserting

Throws 400 Bad Request if memberCount >= group.maxMembers

Migration — 1740600000000-AddMaxMembersToGroups

Adds maxMembers column as nullable, back-fills maxMembers = totalRounds for all existing rows, then sets it non-nullable

Fully reversible via down()

Tests

GroupsService: 3 new tests covering maxMembers != totalRounds, minMembers > maxMembers, and default assignment

MembershipsService: 4 new addMember tests — exactly at cap (throws), one over cap (throws), one below cap (succeeds), boundary at cap - 1 (succeeds)

Acceptance criteria
 Adding a member beyond maxMembers throws 400 Bad Request
 Group creation fails if maxMembers != totalRounds
 Existing groups without maxMembers default to totalRounds via migration back-fill
 Tests cover boundary conditions (exactly at cap, one over cap)
   closes #92

