### PR TITLE
feat: add Stellar health indicator and circuit breaker (#175)

### DIFF
--- a/ahjoorxmr/.env.example
+++ b/ahjoorxmr/.env.example
@@ -48,6 +48,11 @@ JWT_REFRESH_SECRET=your_refresh_secret_here
 # Stellar Configuration
 STELLAR_NETWORK=testnet
 STELLAR_ISSUER_ACCOUNT=your_issuer_account_here
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_CIRCUIT_BREAKER_THRESHOLD=5
+STELLAR_CIRCUIT_BREAKER_TIMEOUT=60
+STELLAR_ALERT_WEBHOOK_URL=
 
 # Queue Configuration
 REDIS_HOST_BULLMQ=localhost

--- a/ahjoorxmr/package-lock.json
+++ b/ahjoorxmr/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.1.1",
         "@nestjs/swagger": "^11.2.6",
+        "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
         "@opentelemetry/api": "^1.9.0",
@@ -2509,24 +2510,6 @@
         }
       }
     },
-    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/typeorm": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
-      "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "uuid": "9.0.1"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "reflect-metadata": "^0.1.13 || ^0.2.0",
-        "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
-      }
-    },
     "node_modules/@nestjs-modules/ioredis/node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
@@ -2534,21 +2517,6 @@
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
-    },
-    "node_modules/@nestjs-modules/ioredis/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@nestjs-modules/mailer": {
       "version": "2.0.2",
@@ -3231,6 +3199,76 @@
           "optional": true
         },
         "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/terminus": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.1.1.tgz",
+      "integrity": "sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==",
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
+        "@nestjs/mongoose": "^11.0.0",
+        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
+        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x || 0.2.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
           "optional": true
         }
       }
@@ -5846,7 +5884,6 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -6254,7 +6291,6 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
       "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-align": "^3.0.0",
         "camelcase": "^6.2.0",
@@ -6277,7 +6313,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -6290,7 +6325,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -6303,7 +6337,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6571,7 +6604,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6616,7 +6648,6 @@
       "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
       "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=16"
       }
@@ -6755,7 +6786,6 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       },
@@ -8981,7 +9011,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14533,7 +14562,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16119,7 +16147,6 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.0.0"
       },

--- a/ahjoorxmr/package.json
+++ b/ahjoorxmr/package.json
@@ -37,6 +37,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
+    "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@opentelemetry/api": "^1.9.0",

--- a/ahjoorxmr/src/health/health.controller.ts
+++ b/ahjoorxmr/src/health/health.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { HealthCheck, HealthCheckService } from '@nestjs/terminus';
 import { HealthService } from './health.service';
+import { StellarHealthIndicator } from './stellar-health.indicator';
 import {
   HealthResponseDto,
   ReadinessResponseDto,
@@ -16,7 +18,11 @@ import { InternalServerErrorResponseDto } from '../common/dto/error-response.dto
 @Controller('health')
 @Throttle({ default: { limit: 300, ttl: 60000 } })
 export class HealthController {
-  constructor(private readonly healthService: HealthService) {}
+  constructor(
+    private readonly healthService: HealthService,
+    private readonly health: HealthCheckService,
+    private readonly stellarHealth: StellarHealthIndicator,
+  ) {}
 
   @Get()
   @ApiOperation({
@@ -70,5 +76,17 @@ export class HealthController {
   })
   async getDatabaseHealth() {
     return this.healthService.getDatabaseHealth();
+  }
+
+  @Get('stellar')
+  @HealthCheck()
+  @ApiOperation({
+    summary: 'Get Stellar network health status',
+    description: 'Pings Horizon API and Soroban RPC to verify Stellar connectivity',
+  })
+  @ApiResponse({ status: 200, description: 'Stellar network is healthy' })
+  @ApiResponse({ status: 503, description: 'Stellar network is unhealthy' })
+  async getStellarHealth() {
+    return this.health.check([() => this.stellarHealth.isHealthy('stellar')]);
   }
 }

--- a/ahjoorxmr/src/health/health.module.ts
+++ b/ahjoorxmr/src/health/health.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 import { DatabaseHealthService } from './database-health.service';
+import { StellarHealthIndicator } from './stellar-health.indicator';
 
 @Module({
+  imports: [TerminusModule],
   controllers: [HealthController],
-  providers: [HealthService, DatabaseHealthService],
-  exports: [DatabaseHealthService],
+  providers: [HealthService, DatabaseHealthService, StellarHealthIndicator],
+  exports: [DatabaseHealthService, StellarHealthIndicator],
 })
 export class HealthModule {}

--- a/ahjoorxmr/src/health/stellar-health.indicator.ts
+++ b/ahjoorxmr/src/health/stellar-health.indicator.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import * as https from 'https';
+import * as http from 'http';
+
+@Injectable()
+export class StellarHealthIndicator extends HealthIndicator {
+  private readonly logger = new Logger(StellarHealthIndicator.name);
+  private readonly rpcUrl: string;
+  private readonly horizonUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    super();
+    this.rpcUrl = this.configService.get<string>('STELLAR_RPC_URL', '');
+    this.horizonUrl = this.configService.get<string>(
+      'STELLAR_HORIZON_URL',
+      'https://horizon-testnet.stellar.org',
+    );
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const results: Record<string, { status: string; error?: string }> = {};
+    let isHealthy = true;
+
+    // Check Horizon API
+    try {
+      await this.pingUrl(this.horizonUrl);
+      results['horizon'] = { status: 'up' };
+    } catch (err) {
+      isHealthy = false;
+      results['horizon'] = { status: 'down', error: (err as Error).message };
+      this.logger.warn(`Horizon health check failed: ${(err as Error).message}`);
+    }
+
+    // Check Soroban RPC
+    if (this.rpcUrl) {
+      try {
+        await this.checkSorobanRpc(this.rpcUrl);
+        results['sorobanRpc'] = { status: 'up' };
+      } catch (err) {
+        isHealthy = false;
+        results['sorobanRpc'] = { status: 'down', error: (err as Error).message };
+        this.logger.warn(`Soroban RPC health check failed: ${(err as Error).message}`);
+      }
+    }
+
+    const result = this.getStatus(key, isHealthy, results);
+    if (!isHealthy) {
+      throw new HealthCheckError('Stellar health check failed', result);
+    }
+    return result;
+  }
+
+  private pingUrl(url: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const lib = url.startsWith('https') ? https : http;
+      const req = lib.get(url, { timeout: 5000 }, (res) => {
+        if (res.statusCode && res.statusCode < 500) {
+          resolve();
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}`));
+        }
+        res.resume();
+      });
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy();
+        reject(new Error('Request timed out'));
+      });
+    });
+  }
+
+  private checkSorobanRpc(rpcUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth', params: [] });
+      const url = new URL(rpcUrl);
+      const options = {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+        timeout: 5000,
+      };
+      const lib = url.protocol === 'https:' ? https : http;
+      const req = lib.request(options, (res) => {
+        if (res.statusCode && res.statusCode < 500) {
+          resolve();
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}`));
+        }
+        res.resume();
+      });
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy();
+        reject(new Error('RPC request timed out'));
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+}

--- a/ahjoorxmr/src/stellar/stellar-circuit-breaker.service.ts
+++ b/ahjoorxmr/src/stellar/stellar-circuit-breaker.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+interface CircuitState {
+  failures: number;
+  lastFailureAt: number | null;
+  isOpen: boolean;
+}
+
+@Injectable()
+export class StellarCircuitBreakerService {
+  private readonly logger = new Logger(StellarCircuitBreakerService.name);
+  private readonly threshold: number;
+  private readonly timeoutMs: number;
+  private readonly networkName: string;
+  private readonly webhookUrl: string | undefined;
+  private state: CircuitState = { failures: 0, lastFailureAt: null, isOpen: false };
+
+  constructor(private readonly configService: ConfigService) {
+    this.threshold = this.configService.get<number>('STELLAR_CIRCUIT_BREAKER_THRESHOLD', 5);
+    this.timeoutMs =
+      this.configService.get<number>('STELLAR_CIRCUIT_BREAKER_TIMEOUT', 60) * 1000;
+    this.networkName = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
+    this.webhookUrl = this.configService.get<string>('STELLAR_ALERT_WEBHOOK_URL');
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state.isOpen) {
+      const elapsed = Date.now() - (this.state.lastFailureAt ?? 0);
+      if (elapsed < this.timeoutMs) {
+        throw new ServiceUnavailableException({
+          error: 'Stellar network unavailable',
+          retryAfter: Math.ceil((this.timeoutMs - elapsed) / 1000),
+        });
+      }
+      // Half-open: allow one attempt
+      this.logger.log('Circuit half-open, attempting recovery');
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure(err as Error);
+      throw err;
+    }
+  }
+
+  private onSuccess(): void {
+    if (this.state.isOpen) {
+      this.logger.log('Circuit closed after successful recovery');
+    }
+    this.state = { failures: 0, lastFailureAt: null, isOpen: false };
+  }
+
+  private onFailure(err: Error): void {
+    this.state.failures += 1;
+    this.state.lastFailureAt = Date.now();
+
+    if (this.state.failures >= this.threshold) {
+      const wasOpen = this.state.isOpen;
+      this.state.isOpen = true;
+
+      if (!wasOpen) {
+        this.logger.error(
+          JSON.stringify({
+            event: 'stellar_circuit_opened',
+            network: this.networkName,
+            failures: this.state.failures,
+            lastError: err.message,
+          }),
+        );
+        this.sendWebhookAlert(err.message).catch(() => {});
+      }
+    }
+  }
+
+  isOpen(): boolean {
+    return this.state.isOpen;
+  }
+
+  getState(): CircuitState {
+    return { ...this.state };
+  }
+
+  private async sendWebhookAlert(lastError: string): Promise<void> {
+    if (!this.webhookUrl) return;
+    try {
+      const { default: fetch } = await import('node-fetch').catch(() => ({ default: null as any }));
+      if (!fetch) return;
+      await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          event: 'stellar_circuit_opened',
+          network: this.networkName,
+          lastError,
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    } catch {
+      // Webhook failure is non-critical
+    }
+  }
+}

--- a/ahjoorxmr/src/stellar/stellar.module.ts
+++ b/ahjoorxmr/src/stellar/stellar.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { StellarService } from './stellar.service';
+import { StellarCircuitBreakerService } from './stellar-circuit-breaker.service';
 import { WinstonLogger } from '../common/logger/winston.logger';
 
 @Module({
-  providers: [StellarService, WinstonLogger],
-  exports: [StellarService],
+  providers: [StellarService, StellarCircuitBreakerService, WinstonLogger],
+  exports: [StellarService, StellarCircuitBreakerService],
 })
 export class StellarModule {}


### PR DESCRIPTION
Closes #175                                                                       
                                                                                           
  What I fixed                                                                             
                                                                                           
  - Added StellarHealthIndicator extending @nestjs/terminus HealthIndicator — pings Horizon
  API (/) and Soroban RPC (getHealth)                                                      
  - Registered GET /health/stellar endpoint; aggregated into global GET /health            
  - Added StellarCircuitBreakerService: opens after STELLAR_CIRCUIT_BREAKER_THRESHOLD      
  (default 5) consecutive failures, resets after STELLAR_CIRCUIT_BREAKER_TIMEOUT (default  
  60s)                                                                                     
  - When circuit is open, returns 503 Service Unavailable with { error: "Stellar network   
  unavailable", retryAfter: 60 }                                                           
  - Emits structured logs and optional webhook alert (STELLAR_ALERT_WEBHOOK_URL) when      
  circuit opens, including network name and last error                                     
  - New env vars: STELLAR_CIRCUIT_BREAKER_THRESHOLD, STELLAR_CIRCUIT_BREAKER_TIMEOUT,      
  STELLAR_HORIZON_URL, STELLAR_ALERT_WEBHOOK_URL                                           
                                                