### PR TITLE
feat: BullMQ exponential backoff, job_failures entity, admin endpoint…

### DIFF
--- a/ahjoorxmr/migrations/1745100000000-CreateJobFailuresTable.ts
+++ b/ahjoorxmr/migrations/1745100000000-CreateJobFailuresTable.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateJobFailuresTable1745100000000 implements MigrationInterface {
+  name = 'CreateJobFailuresTable1745100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "job_failures" (
+        "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+        "jobId" VARCHAR(255) NOT NULL,
+        "jobName" VARCHAR(255) NOT NULL,
+        "queueName" VARCHAR(255) NOT NULL,
+        "failedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "error" TEXT NOT NULL,
+        "stackTrace" TEXT,
+        "attemptNumber" INTEGER NOT NULL DEFAULT 1,
+        "data" JSONB,
+        "retryCount" INTEGER NOT NULL DEFAULT 0,
+        CONSTRAINT "PK_job_failures" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_job_failures_queue_failed" ON "job_failures" ("queueName", "failedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_job_failures_job_name" ON "job_failures" ("jobName")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "job_failures"`);
+  }
+}

--- a/ahjoorxmr/src/app.module.ts
+++ b/ahjoorxmr/src/app.module.ts
@@ -24,6 +24,7 @@ import { Contribution } from './contributions/entities/contribution.entity';
 import { AuditLog } from './audit/entities/audit-log.entity';
 import { KycDocument } from './kyc/entities/kyc-document.entity';
 import { PayoutTransaction } from './groups/entities/payout-transaction.entity';
+import { JobFailure } from './bullmq/entities/job-failure.entity';
 import { KycModule } from './kyc/kyc.module';
 import { StellarModule } from './stellar/stellar.module';
 import { EventListenerModule } from './event-listener/event-listener.module';
@@ -62,6 +63,7 @@ import { CorrelationIdMiddleware } from './common/middleware/correlation-id.midd
             AuditLog,
             KycDocument,
             PayoutTransaction,
+            JobFailure,
           ],
           synchronize: isDevelopment, // Auto-create tables only in development
           logging: isDevelopment, // Enable logging only in development

--- a/ahjoorxmr/src/bullmq/entities/job-failure.entity.ts
+++ b/ahjoorxmr/src/bullmq/entities/job-failure.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, Index } from 'typeorm';
+
+@Entity('job_failures')
+@Index(['queueName', 'failedAt'])
+@Index(['jobName'])
+export class JobFailure {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('varchar', { length: 255 })
+  jobId: string;
+
+  @Column('varchar', { length: 255 })
+  jobName: string;
+
+  @Column('varchar', { length: 255 })
+  queueName: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  failedAt: Date;
+
+  @Column('text')
+  error: string;
+
+  @Column('text', { nullable: true })
+  stackTrace: string | null;
+
+  @Column('int', { default: 1 })
+  attemptNumber: number;
+
+  @Column('jsonb', { nullable: true })
+  data: Record<string, unknown> | null;
+
+  @Column('int', { default: 0 })
+  retryCount: number;
+}

--- a/ahjoorxmr/src/bullmq/job-failure.service.ts
+++ b/ahjoorxmr/src/bullmq/job-failure.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, FindOptionsWhere } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { JobFailure } from './entities/job-failure.entity';
+import { QUEUE_NAMES } from './queue.constants';
+
+export interface JobFailureFilter {
+  queueName?: string;
+  jobName?: string;
+  from?: string;
+  to?: string;
+  page?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class JobFailureService {
+  private readonly logger = new Logger(JobFailureService.name);
+
+  constructor(
+    @InjectRepository(JobFailure)
+    private readonly repo: Repository<JobFailure>,
+    @InjectQueue(QUEUE_NAMES.EMAIL) private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EVENT_SYNC) private readonly eventSyncQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.GROUP_SYNC) private readonly groupSyncQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.PAYOUT_RECONCILIATION)
+    private readonly payoutQueue: Queue,
+  ) {}
+
+  async persist(
+    jobId: string,
+    jobName: string,
+    queueName: string,
+    error: Error,
+    attemptNumber: number,
+    data: Record<string, unknown> | null,
+  ): Promise<void> {
+    try {
+      await this.repo.save(
+        this.repo.create({
+          jobId,
+          jobName,
+          queueName,
+          error: error.message,
+          stackTrace: error.stack ?? null,
+          attemptNumber,
+          data,
+        }),
+      );
+    } catch (err) {
+      this.logger.error(`Failed to persist job failure: ${(err as Error).message}`);
+    }
+  }
+
+  async findAll(filter: JobFailureFilter): Promise<{ data: JobFailure[]; total: number }> {
+    const { queueName, jobName, from, to, page = 1, limit = 20 } = filter;
+    const where: FindOptionsWhere<JobFailure> = {};
+
+    if (queueName) where.queueName = queueName;
+    if (jobName) where.jobName = jobName;
+    if (from || to) {
+      where.failedAt = Between(
+        from ? new Date(from) : new Date(0),
+        to ? new Date(to) : new Date(),
+      );
+    }
+
+    const [data, total] = await this.repo.findAndCount({
+      where,
+      order: { failedAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total };
+  }
+
+  async retryAll(): Promise<{ retried: number }> {
+    // Get all failed jobs from all queues and re-enqueue them
+    const queues: Queue[] = [
+      this.emailQueue,
+      this.eventSyncQueue,
+      this.groupSyncQueue,
+      this.payoutQueue,
+    ];
+
+    let retried = 0;
+    for (const queue of queues) {
+      const failedJobs = await queue.getFailed();
+      for (const job of failedJobs) {
+        try {
+          await job.retry();
+          // Increment retryCount in our persistence table
+          await this.repo.increment({ jobId: String(job.id) }, 'retryCount', 1);
+          retried++;
+        } catch (err) {
+          this.logger.warn(`Failed to retry job ${job.id}: ${(err as Error).message}`);
+        }
+      }
+    }
+
+    this.logger.log(`Retried ${retried} failed jobs`);
+    return { retried };
+  }
+
+  async getMetrics(): Promise<{ jobs_failed_total: number; jobs_failed_by_queue: Record<string, number> }> {
+    const total = await this.repo.count();
+    const byQueue = await this.repo
+      .createQueryBuilder('jf')
+      .select('jf.queueName', 'queueName')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('jf.queueName')
+      .getRawMany<{ queueName: string; count: string }>();
+
+    const jobs_failed_by_queue: Record<string, number> = {};
+    for (const row of byQueue) {
+      jobs_failed_by_queue[row.queueName] = parseInt(row.count, 10);
+    }
+
+    return { jobs_failed_total: total, jobs_failed_by_queue };
+  }
+}

--- a/ahjoorxmr/src/bullmq/job-failures-admin.controller.ts
+++ b/ahjoorxmr/src/bullmq/job-failures-admin.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Version,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JobFailureService, JobFailureFilter } from './job-failure.service';
+
+@ApiTags('Admin – Job Failures')
+@ApiBearerAuth()
+@Controller('admin/jobs/failures')
+@Version('1')
+export class JobFailuresAdminController {
+  constructor(private readonly jobFailureService: JobFailureService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get paginated job failures (admin only)' })
+  @ApiQuery({ name: 'queueName', required: false })
+  @ApiQuery({ name: 'jobName', required: false })
+  @ApiQuery({ name: 'from', required: false, description: 'ISO date string' })
+  @ApiQuery({ name: 'to', required: false, description: 'ISO date string' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated job failures' })
+  async getFailures(@Query() query: JobFailureFilter) {
+    const { data, total } = await this.jobFailureService.findAll(query);
+    return {
+      data,
+      total,
+      page: Number(query.page ?? 1),
+      limit: Number(query.limit ?? 20),
+    };
+  }
+
+  @Post('retry-all')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retry all failed jobs across all queues (admin only)' })
+  @ApiResponse({ status: 200, description: 'Number of jobs retried' })
+  async retryAll() {
+    return this.jobFailureService.retryAll();
+  }
+}

--- a/ahjoorxmr/src/bullmq/queue.module.ts
+++ b/ahjoorxmr/src/bullmq/queue.module.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common';
-import { BullModule } from '@nestjs/bullmq';
+import { Module, OnModuleInit } from '@nestjs/common';
+import { BullModule, InjectQueue } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Queue } from 'bullmq';
 
 import { QUEUE_NAMES, BACKOFF_DELAYS, RETRY_CONFIG } from './queue.constants';
 import { QueueService } from './queue.service';
@@ -12,6 +13,9 @@ import { EmailProcessor } from './email.processor';
 import { EventSyncProcessor } from './event-sync.processor';
 import { GroupSyncProcessor } from './group-sync.processor';
 import { PayoutReconciliationProcessor } from './payout-reconciliation.processor';
+import { JobFailureService } from './job-failure.service';
+import { JobFailuresAdminController } from './job-failures-admin.controller';
+import { JobFailure } from './entities/job-failure.entity';
 import { MailModule } from '../mail/mail.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { NotificationsModule } from '../notification/notifications.module';
@@ -19,6 +23,7 @@ import { Group } from '../groups/entities/group.entity';
 import { Contribution } from '../contributions/entities/contribution.entity';
 import { Membership } from '../memberships/entities/membership.entity';
 import { PayoutTransaction } from '../groups/entities/payout-transaction.entity';
+import { Logger } from '@nestjs/common';
 
 /**
  * Custom backoff strategy registered globally via BullMQ worker options.
@@ -33,8 +38,8 @@ function customBackoffStrategy(attemptsMade: number): number {
 // Shared default job options applied at the queue level
 const sharedQueueOptions = {
   defaultJobOptions: {
-    attempts: RETRY_CONFIG.attempts,
-    backoff: { type: 'custom' as const },
+    attempts: 5,
+    backoff: { type: 'exponential' as const, delay: 2000 },
     removeOnComplete: { count: 1000, age: 86_400 },
     removeOnFail: false,
   },
@@ -51,6 +56,7 @@ const sharedQueueOptions = {
       Contribution,
       Membership,
       PayoutTransaction,
+      JobFailure,
     ]),
 
     // Register BullMQ with the shared ioredis client from RedisModule
@@ -85,7 +91,7 @@ const sharedQueueOptions = {
       },
     ),
   ],
-  controllers: [QueueAdminController],
+  controllers: [QueueAdminController, JobFailuresAdminController],
   providers: [
     DeadLetterService,
     QueueService,
@@ -94,12 +100,52 @@ const sharedQueueOptions = {
     EventSyncProcessor,
     GroupSyncProcessor,
     PayoutReconciliationProcessor,
+    JobFailureService,
   ],
   exports: [
     QueueService,
     BullBoardService,
+    JobFailureService,
     // Re-export BullModule so consuming modules can inject the queues directly if needed
     BullModule,
   ],
 })
-export class QueueModule {}
+export class QueueModule implements OnModuleInit {
+  private readonly logger = new Logger(QueueModule.name);
+
+  constructor(
+    private readonly jobFailureService: JobFailureService,
+    @InjectQueue(QUEUE_NAMES.EMAIL) private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EVENT_SYNC) private readonly eventSyncQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.GROUP_SYNC) private readonly groupSyncQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.PAYOUT_RECONCILIATION) private readonly payoutQueue: Queue,
+  ) {}
+
+  onModuleInit() {
+    const queues: Queue[] = [
+      this.emailQueue,
+      this.eventSyncQueue,
+      this.groupSyncQueue,
+      this.payoutQueue,
+    ];
+
+    for (const queue of queues) {
+      queue.on('failed', (job, err) => {
+        if (!job) return;
+        this.jobFailureService
+          .persist(
+            String(job.id),
+            job.name,
+            queue.name,
+            err,
+            job.attemptsMade,
+            job.data as Record<string, unknown>,
+          )
+          .catch((persistErr) =>
+            this.logger.error(`Failed to persist job failure: ${persistErr.message}`),
+          );
+      });
+    }
+    this.logger.log('Global BullMQ failed event listeners registered');
+  }
+}


### PR DESCRIPTION
Closes #177                                                                            
                                                                                           
  What changed                                                                             
                                                                                           
  - Configured exponential backoff on all BullMQ queues: attempts: 5, backoff: { type:     
  'exponential', delay: 2000 } (retries at 2s, 4s, 8s, 16s, 32s)                           
  - Added JobFailure entity (job_failures table) with fields: id, jobId, jobName,          
  queueName, failedAt (timestamptz), error, stackTrace, attemptNumber, data (jsonb),       
  - Added migration 1745100000000-CreateJobFailuresTable                                   
  - Registered a global on('failed') listener in QueueModule.onModuleInit that persists    
  every failure via JobFailureService                                                      
  - Added GET /admin/jobs/failures — paginated failures with filters for queueName,        
  jobName, from, to                                                                        
  - Added POST /admin/jobs/failures/retry-all — re-enqueues all failed jobs and increments 
  retryCount                                                                               
  - Added getMetrics() exposing jobs_failed_total and jobs_failed_by_queue