### PR TITLE
feat: add contribution receipt PDF generation and download endpoint

### DIFF
--- a/ahjoorxmr/src/contributions/contributions.controller.ts
+++ b/ahjoorxmr/src/contributions/contributions.controller.ts
@@ -11,9 +11,11 @@ import {
   ParseUUIDPipe,
   ParseIntPipe,
   Request,
+  Res,
   Version,
   UseInterceptors,
 } from '@nestjs/common';
+import { Response } from 'express';
 import {
   ApiTags,
   ApiOperation,
@@ -26,6 +28,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { ContributionsService } from './contributions.service';
+import { ReceiptService } from './receipt.service';
 import { CreateContributionDto } from './dto/create-contribution.dto';
 import { ContributionResponseDto } from './dto/contribution-response.dto';
 import { GetContributionsQueryDto } from './dto/get-contributions-query.dto';
@@ -46,7 +49,10 @@ import {
 @ApiTags('Contributions')
 @Controller()
 export class ContributionsController {
-  constructor(private readonly contributionsService: ContributionsService) {}
+  constructor(
+    private readonly contributionsService: ContributionsService,
+    private readonly receiptService: ReceiptService,
+  ) {}
 
   /**
    * Creates a new contribution record (internal endpoint).
@@ -270,5 +276,21 @@ export class ContributionsController {
       createdAt: contribution.createdAt.toISOString(),
       updatedAt: contribution.updatedAt.toISOString(),
     }));
+  }
+
+  @Get('contributions/:id/receipt')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Download PDF receipt for a contribution (owner or admin only)' })
+  @ApiParam({ name: 'id', description: 'Contribution UUID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'PDF receipt streamed successfully' })
+  @ApiResponse({ status: 403, description: 'Access denied', type: ErrorResponseDto })
+  @ApiResponse({ status: 404, description: 'Contribution not found', type: ErrorResponseDto })
+  async downloadReceipt(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: { user: { id: string; userId: string } },
+    @Res() res: Response,
+  ): Promise<void> {
+    const userId = req.user.id || req.user.userId;
+    await this.receiptService.streamReceiptPdf(id, userId, res);
   }
 }

--- a/ahjoorxmr/src/contributions/contributions.module.ts
+++ b/ahjoorxmr/src/contributions/contributions.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContributionsController } from './contributions.controller';
 import { ContributionsService } from './contributions.service';
+import { ReceiptService } from './receipt.service';
 import { Contribution } from './entities/contribution.entity';
 import { Group } from '../groups/entities/group.entity';
 import { Membership } from '../memberships/entities/membership.entity';
@@ -32,7 +33,7 @@ import { QueueModule } from '../bullmq/queue.module';
     forwardRef(() => QueueModule),
   ],
   controllers: [ContributionsController],
-  providers: [ContributionsService, WinstonLogger, ApiKeyGuard, JwtAuthGuard],
+  providers: [ContributionsService, ReceiptService, WinstonLogger, ApiKeyGuard, JwtAuthGuard],
   exports: [ContributionsService],
 })
 export class ContributionsModule {}

--- a/ahjoorxmr/src/contributions/receipt.service.ts
+++ b/ahjoorxmr/src/contributions/receipt.service.ts
@@ -1,0 +1,136 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as PDFDocument from 'pdfkit';
+import { Contribution } from './entities/contribution.entity';
+import { Membership } from '../memberships/entities/membership.entity';
+import { User } from '../users/entities/user.entity';
+import { Response } from 'express';
+
+const STELLAR_EXPLORER_BASE = 'https://stellar.expert/explorer/public/tx';
+
+@Injectable()
+export class ReceiptService {
+  constructor(
+    @InjectRepository(Contribution)
+    private readonly contributionRepo: Repository<Contribution>,
+    @InjectRepository(Membership)
+    private readonly membershipRepo: Repository<Membership>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async streamReceiptPdf(
+    contributionId: string,
+    requestingUserId: string,
+    res: Response,
+  ): Promise<void> {
+    const contribution = await this.contributionRepo.findOne({
+      where: { id: contributionId },
+      relations: ['group'],
+    });
+
+    if (!contribution) {
+      throw new NotFoundException('Contribution not found');
+    }
+
+    const requestingUser = await this.userRepo.findOne({
+      where: { id: requestingUserId },
+    });
+
+    const isOwner = contribution.userId === requestingUserId;
+    const isAdmin = requestingUser?.role === 'admin';
+
+    if (!isOwner && !isAdmin) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    const membership = await this.membershipRepo.findOne({
+      where: { groupId: contribution.groupId, userId: contribution.userId },
+    });
+
+    const doc = new PDFDocument({ margin: 50, size: 'A4' });
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="receipt-${contributionId}.pdf"`,
+    );
+
+    doc.pipe(res);
+
+    // ── Header ──────────────────────────────────────────────────────────────
+    doc
+      .fontSize(22)
+      .font('Helvetica-Bold')
+      .text('Ahjoorxmr — ROSCA Platform', { align: 'center' });
+    doc
+      .fontSize(13)
+      .font('Helvetica')
+      .text('Contribution Receipt', { align: 'center' });
+    doc.moveDown(0.5);
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).strokeColor('#cccccc').stroke();
+    doc.moveDown(1);
+
+    // ── Helper ───────────────────────────────────────────────────────────────
+    const addRow = (label: string, value: string) => {
+      doc.font('Helvetica-Bold').fontSize(11).text(`${label}:  `, {
+        continued: true,
+        lineBreak: false,
+      });
+      doc.font('Helvetica').fontSize(11).text(value);
+      doc.moveDown(0.4);
+    };
+
+    // ── Fields ───────────────────────────────────────────────────────────────
+    addRow('Contribution ID', contribution.id);
+    addRow('Group Name', contribution.group?.name ?? 'N/A');
+    addRow('Round Number', String(contribution.roundNumber ?? 'N/A'));
+    addRow(
+      'Amount',
+      `${contribution.amount} ${contribution.assetCode ?? 'XLM'}`,
+    );
+    addRow(
+      'Member Wallet',
+      membership?.walletAddress ?? contribution.walletAddress ?? 'N/A',
+    );
+    addRow(
+      'Contribution Date',
+      new Date(contribution.createdAt).toUTCString(),
+    );
+    addRow('Status', contribution.status ?? 'N/A');
+
+    if (contribution.transactionHash) {
+      addRow('Transaction Hash', contribution.transactionHash);
+      const explorerUrl = `${STELLAR_EXPLORER_BASE}/${contribution.transactionHash}`;
+      doc.moveDown(0.2);
+      doc
+        .font('Helvetica')
+        .fontSize(10)
+        .fillColor('#0066cc')
+        .text('View on Stellar Explorer →', { link: explorerUrl, underline: true })
+        .fillColor('black');
+      doc.moveDown(0.4);
+    }
+
+    // ── Footer ───────────────────────────────────────────────────────────────
+    doc.moveDown(1.5);
+    doc.moveTo(50, doc.y).lineTo(545, doc.y).strokeColor('#cccccc').stroke();
+    doc.moveDown(0.5);
+    doc
+      .fontSize(9)
+      .font('Helvetica')
+      .fillColor('#888888')
+      .text(
+        'This is an auto-generated receipt. Please retain it for your records.',
+        { align: 'center' },
+      )
+      .fillColor('black');
+
+    doc.end();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /contributions/:id/receipt` endpoint (JWT guarded, owner or admin only)
- Uses `pdfkit` to stream a PDF containing: Contribution ID, Group Name, Round, Amount + asset code, Member Wallet, Timestamp, Status, and a clickable Stellar Explorer deep-link for the transaction hash
- Returns `403 Forbidden` for non-owners and `404 Not Found` for missing contributions
- PDF streamed directly with `Content-Type: application/pdf` and `Content-Disposition: attachment; filename="receipt-<id>.pdf"`
- No disk storage required — streamed on every request

## Test plan

- [ ] `GET /contributions/:id/receipt` as contribution owner → returns valid PDF download
- [ ] Non-owner receives `403 Forbidden`
- [ ] Non-existent contribution returns `404 Not Found`
- [ ] PDF contains all required fields including Stellar Explorer deep-link

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)