### PR TITLE
 Group Templates: Save and Reuse Group Configuration Presets 

### DIFF
--- a/ahjoorxmr/migrations/1748100000000-CreateGroupTemplatesTable.ts
+++ b/ahjoorxmr/migrations/1748100000000-CreateGroupTemplatesTable.ts
@@ -1,0 +1,105 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from 'typeorm';
+
+export class CreateGroupTemplatesTable1748100000000 implements MigrationInterface {
+  name = 'CreateGroupTemplatesTable1748100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'group_templates',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+            length: '1000',
+            isNullable: true,
+            default: null,
+          },
+          {
+            name: 'isPublic',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'config',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'ownerId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'usageCount',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp with time zone',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp with time zone',
+            default: 'now()',
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamp with time zone',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create index on ownerId for fast lookup of user's templates
+    await queryRunner.createIndex(
+      'group_templates',
+      new TableIndex({
+        name: 'idx_group_templates_owner_id',
+        columnNames: ['ownerId'],
+      }),
+    );
+
+    // Create partial index on isPublic for fast lookup of public templates
+    await queryRunner.createIndex(
+      'group_templates',
+      new TableIndex({
+        name: 'idx_group_templates_public',
+        columnNames: ['isPublic'],
+        where: '"isPublic" = true',
+      }),
+    );
+
+    // Add foreign key constraint on ownerId
+    await queryRunner.createForeignKey(
+      'group_templates',
+      new TableForeignKey({
+        columnNames: ['ownerId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('group_templates', true);
+  }
+}

--- a/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
+++ b/ahjoorxmr/src/groups/__tests__/groups.service.spec.ts
@@ -20,6 +20,7 @@ import { StellarService } from '../../stellar/stellar.service';
 import { AuditService } from '../../audit/audit.service';
 import { TransferAdminDto } from '../dto/transfer-admin.dto';
 import { ConfigService } from '@nestjs/config';
+import { GroupTemplatesService } from '../group-templates.service';
 
 // ---------------------------------------------------------------------------
 // Mock factories
@@ -110,22 +111,28 @@ describe('GroupsService', () => {
   let stellarService: Partial<StellarService>;
   let auditService: Partial<AuditService>;
   let mockDataSource: Partial<DataSource>;
+  let groupTemplatesService: Partial<GroupTemplatesService>;
 
-  beforeEach(async () => {
-    groupRepository = createMockRepository<Group>();
-    membershipRepository = createMockRepository<Membership>();
-    logger = createMockLogger();
-    notificationsService = {
-      notify: jest.fn().mockResolvedValue({}),
-      notifyBatch: jest.fn().mockResolvedValue([]),
-    };
-    stellarService = {
-      deployRoscaContract: jest.fn().mockResolvedValue('CFAKEADDRESS123'),
-      disbursePayout: jest.fn().mockResolvedValue('TX_HASH_MOCK'),
-    };
-    auditService = {
-      createLog: jest.fn().mockResolvedValue({}),
-    };
+   beforeEach(async () => {
+     groupRepository = createMockRepository<Group>();
+     membershipRepository = createMockRepository<Membership>();
+     logger = createMockLogger();
+     notificationsService = {
+       notify: jest.fn().mockResolvedValue({}),
+       notifyBatch: jest.fn().mockResolvedValue([]),
+     };
+     stellarService = {
+       deployRoscaContract: jest.fn().mockResolvedValue('CFAKEADDRESS123'),
+       disbursePayout: jest.fn().mockResolvedValue('TX_HASH_MOCK'),
+     };
+     auditService = {
+       createLog: jest.fn().mockResolvedValue({}),
+     };
+     groupTemplatesService = {
+       findTemplateById: jest.fn(),
+       mergeTemplateConfig: jest.fn().mockImplementation((template, dto) => dto),
+       incrementUsageCount: jest.fn(),
+     };
 
     // Default DataSource mock: transaction callback runs immediately
     const mockEntityManager = {
@@ -141,45 +148,49 @@ describe('GroupsService', () => {
       transaction: jest.fn().mockImplementation((cb) => cb(mockEntityManager)),
     } as any;
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        GroupsService,
-        {
-          provide: getRepositoryToken(Group),
-          useValue: groupRepository,
-        },
-        {
-          provide: getRepositoryToken(Membership),
-          useValue: membershipRepository,
-        },
-        {
-          provide: WinstonLogger,
-          useValue: logger,
-        },
-        {
-          provide: NotificationsService,
-          useValue: notificationsService,
-        },
-        {
-          provide: StellarService,
-          useValue: stellarService,
-        },
-        {
-          provide: AuditService,
-          useValue: auditService,
-        },
-        {
-          provide: DataSource,
-          useValue: mockDataSource,
-        },
-        {
-          provide: ConfigService,
-          useValue: {
-            get: jest.fn(),
-          },
-        },
-      ],
-    }).compile();
+     const module: TestingModule = await Test.createTestingModule({
+       providers: [
+         GroupsService,
+         {
+           provide: getRepositoryToken(Group),
+           useValue: groupRepository,
+         },
+         {
+           provide: getRepositoryToken(Membership),
+           useValue: membershipRepository,
+         },
+         {
+           provide: WinstonLogger,
+           useValue: logger,
+         },
+         {
+           provide: NotificationsService,
+           useValue: notificationsService,
+         },
+         {
+           provide: StellarService,
+           useValue: stellarService,
+         },
+         {
+           provide: AuditService,
+           useValue: auditService,
+         },
+         {
+           provide: DataSource,
+           useValue: mockDataSource,
+         },
+         {
+           provide: ConfigService,
+           useValue: {
+             get: jest.fn(),
+           },
+         },
+         {
+           provide: GroupTemplatesService,
+           useValue: groupTemplatesService,
+         },
+       ],
+     }).compile();
 
     service = module.get<GroupsService>(GroupsService);
   });
@@ -330,6 +341,53 @@ describe('GroupsService', () => {
         'DB failure',
       );
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should apply template configuration and increment usage count when templateId is provided', async () => {
+      const templateId = 'temp-uuid';
+      const mockTemplate = {
+        id: templateId,
+        config: {
+          contributionAmount: '200.00',
+          roundDuration: 2592000,
+          totalRounds: 12,
+          maxMembers: 12,
+          minMembers: 3,
+          assetCode: 'USDC',
+          assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+          payoutOrderStrategy: 'SEQUENTIAL',
+          penaltyRate: 0.05,
+          gracePeriodHours: 24,
+          timezone: 'UTC',
+        },
+        isPublic: false,
+        ownerId: BASE_USER_ID,
+      } as any;
+
+      (groupTemplatesService.findTemplateById as jest.Mock).mockResolvedValue(mockTemplate);
+      (groupTemplatesService.mergeTemplateConfig as jest.Mock).mockReturnValue({
+        ...dto,
+        assetCode: 'USDC',
+        assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+        payoutOrderStrategy: 'SEQUENTIAL',
+        penaltyRate: 0.05,
+        gracePeriodHours: 24,
+        timezone: 'UTC',
+      });
+
+      const mockSavedGroup = createMockGroup();
+      groupRepository.create!.mockReturnValue(mockSavedGroup);
+      groupRepository.save!.mockResolvedValue(mockSavedGroup);
+
+      await service.createGroup(
+        { ...dto, templateId } as any,
+        ADMIN_WALLET,
+        BASE_USER_ID,
+      );
+
+      expect(groupTemplatesService.findTemplateById).toHaveBeenCalledWith(templateId, BASE_USER_ID);
+      expect(groupTemplatesService.mergeTemplateConfig).toHaveBeenCalledWith(mockTemplate, expect.objectContaining({ templateId }));
+      expect(groupTemplatesService.incrementUsageCount).toHaveBeenCalledWith(templateId);
     });
   });
 

--- a/ahjoorxmr/src/groups/dto/create-group.dto.ts
+++ b/ahjoorxmr/src/groups/dto/create-group.dto.ts
@@ -114,4 +114,36 @@ export class CreateGroupDto {
   @IsOptional()
   @IsDateString()
   endDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Payout order strategy (e.g., SEQUENTIAL, RANDOM)',
+    example: 'SEQUENTIAL',
+  })
+  @IsOptional()
+  @IsString()
+  payoutOrderStrategy?: string;
+
+  @ApiPropertyOptional({
+    description: 'Penalty rate for missed contributions (0-1)',
+    example: 0.05,
+  })
+  @IsOptional()
+  penaltyRate?: number;
+
+  @ApiPropertyOptional({
+    description: 'Grace period in hours before a member is penalized',
+    example: 24,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  gracePeriodHours?: number;
+
+  @ApiPropertyOptional({
+    description: 'UUID of a group template to use as base configuration. When provided, template config is merged as defaults (explicit DTO fields override template values).',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsOptional()
+  @IsString()
+  templateId?: string;
 }

--- a/ahjoorxmr/src/groups/dto/group-template-response.dto.ts
+++ b/ahjoorxmr/src/groups/dto/group-template-response.dto.ts
@@ -1,0 +1,121 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Configuration object in the response.
+ */
+export class GroupTemplateConfigResponseDto {
+  @ApiProperty()
+  contributionAmount: string;
+
+  @ApiProperty()
+  roundDuration: number;
+
+  @ApiProperty()
+  totalRounds: number;
+
+  @ApiProperty()
+  maxMembers: number;
+
+  @ApiProperty()
+  minMembers: number;
+
+  @ApiPropertyOptional()
+  assetCode?: string;
+
+  @ApiPropertyOptional()
+  assetIssuer?: string | null;
+
+  @ApiPropertyOptional()
+  payoutOrderStrategy?: string;
+
+  @ApiPropertyOptional()
+  penaltyRate?: number;
+
+  @ApiPropertyOptional()
+  gracePeriodHours?: number;
+
+  @ApiPropertyOptional()
+  timezone?: string | null;
+}
+
+/**
+ * Response DTO for a single group template.
+ */
+export class GroupTemplateResponseDto {
+  @ApiProperty({
+    description: 'Template unique identifier',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Name of the template',
+    example: 'Monthly USDC Group',
+  })
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the template',
+    example: 'Template for monthly USDC contribution groups with 12 rounds',
+  })
+  description: string | null;
+
+  @ApiProperty({
+    description: 'Whether this template is publicly visible',
+  })
+  isPublic: boolean;
+
+  @ApiProperty({
+    description: 'Configuration object',
+    type: GroupTemplateConfigResponseDto,
+  })
+  config: GroupTemplateConfigResponseDto;
+
+  @ApiProperty({
+    description: 'UUID of the template owner',
+  })
+  ownerId: string;
+
+  @ApiProperty({
+    description: 'Number of times this template has been used to create a group',
+  })
+  usageCount: number;
+
+  @ApiProperty({
+    description: 'Template creation timestamp',
+    example: '2025-01-15T10:30:00Z',
+  })
+  createdAt: string;
+
+  @ApiProperty({
+    description: 'Template last update timestamp',
+    example: '2025-01-15T10:30:00Z',
+  })
+  updatedAt: string;
+}
+
+/**
+ * Paginated response for group templates.
+ */
+export class PaginatedGroupTemplatesResponseDto {
+  @ApiProperty({
+    description: 'Array of group templates',
+    type: [GroupTemplateResponseDto],
+  })
+  data: GroupTemplateResponseDto[];
+
+  @ApiProperty({
+    description: 'Total number of templates',
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Current page number',
+  })
+  page: number;
+
+  @ApiProperty({
+    description: 'Items per page',
+  })
+  limit: number;
+}

--- a/ahjoorxmr/src/groups/dto/group-template.dto.ts
+++ b/ahjoorxmr/src/groups/dto/group-template.dto.ts
@@ -152,14 +152,14 @@ export class CreateGroupTemplateDto {
   @IsBoolean()
   isPublic?: boolean;
 
-  @ApiProperty({
-    description: 'Configuration object containing group settings',
+  @ApiPropertyOptional({
+    description: 'Configuration object containing group settings. Required if fromGroupId is not provided.',
     type: GroupTemplateConfigDto,
   })
   @Type(() => GroupTemplateConfigDto)
+  @IsOptional()
   @IsObject()
-  @IsNotEmpty()
-  config: GroupTemplateConfigDto;
+  config?: GroupTemplateConfigDto;
 
   @ApiPropertyOptional({
     description: 'Group ID to clone configuration from (instead of providing config directly)',

--- a/ahjoorxmr/src/groups/dto/group-template.dto.ts
+++ b/ahjoorxmr/src/groups/dto/group-template.dto.ts
@@ -1,0 +1,207 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  IsOptional,
+  IsBoolean,
+  Min,
+  MinLength,
+  Matches,
+  IsTimeZone,
+  MaxLength,
+  ValidateIf,
+  IsObject,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+/**
+ * DTO for the template configuration object.
+ * Contains the reusable group settings.
+ */
+export class GroupTemplateConfigDto {
+  @ApiProperty({
+    description: 'Contribution amount per round',
+    example: '100.00',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+(\.\d+)?$/, {
+    message: 'contributionAmount must be a non-negative decimal number',
+  })
+  contributionAmount: string;
+
+  @ApiProperty({
+    description: 'Duration of each round in seconds',
+    example: 2592000,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  roundDuration: number;
+
+  @ApiProperty({
+    description: 'Total number of rounds in the ROSCA cycle',
+    example: 12,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  totalRounds: number;
+
+  @ApiProperty({
+    description: 'Maximum number of members allowed (must equal totalRounds)',
+    example: 12,
+  })
+  @IsInt()
+  @Min(1)
+  maxMembers: number;
+
+  @ApiProperty({
+    description: 'Minimum number of members required to activate the group',
+    example: 3,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  minMembers: number;
+
+  @ApiPropertyOptional({
+    description: 'Stellar asset code (defaults to XLM)',
+    example: 'USDC',
+    default: 'XLM',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(12)
+  assetCode?: string;
+
+  @ApiPropertyOptional({
+    description: 'Stellar account ID of the asset issuer',
+    example: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  })
+  @ValidateIf((o) => o.assetCode && o.assetCode !== 'XLM')
+  @IsString()
+  @IsNotEmpty({ message: 'assetIssuer is required for non-XLM assets' })
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message: 'assetIssuer must be a valid Stellar G-address',
+  })
+  assetIssuer?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Payout order strategy',
+    example: 'SEQUENTIAL',
+  })
+  @IsOptional()
+  @IsString()
+  payoutOrderStrategy?: string;
+
+  @ApiPropertyOptional({
+    description: 'Penalty rate for missed contributions',
+    example: 0.05,
+  })
+  @IsOptional()
+  @IsInt()
+  penaltyRate?: number;
+
+  @ApiPropertyOptional({
+    description: 'Grace period in hours before a member is penalized',
+    example: 24,
+  })
+  @IsOptional()
+  @IsInt()
+  gracePeriodHours?: number;
+
+  @ApiPropertyOptional({
+    description: 'Timezone for the group',
+    example: 'UTC',
+  })
+  @IsOptional()
+  @IsTimeZone()
+  timezone?: string | null;
+}
+
+/**
+ * DTO for creating a new group template.
+ * Can be created from scratch or from an existing group.
+ */
+export class CreateGroupTemplateDto {
+  @ApiProperty({
+    description: 'Name of the template',
+    example: 'Monthly USDC Group',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the template',
+    example: 'Template for monthly USDC contribution groups with 12 rounds',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this template is publicly visible to all users',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+
+  @ApiProperty({
+    description: 'Configuration object containing group settings',
+    type: GroupTemplateConfigDto,
+  })
+  @Type(() => GroupTemplateConfigDto)
+  @IsObject()
+  @IsNotEmpty()
+  config: GroupTemplateConfigDto;
+
+  @ApiPropertyOptional({
+    description: 'Group ID to clone configuration from (instead of providing config directly)',
+  })
+  @IsOptional()
+  @IsString()
+  fromGroupId?: string;
+}
+
+/**
+ * DTO for updating an existing group template.
+ */
+export class UpdateGroupTemplateDto {
+  @ApiPropertyOptional({
+    description: 'Name of the template',
+    example: 'Monthly USDC Group',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the template',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether this template is publicly visible to all users',
+  })
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Configuration object containing group settings',
+    type: GroupTemplateConfigDto,
+  })
+  @IsOptional()
+  @Type(() => GroupTemplateConfigDto)
+  config?: Partial<GroupTemplateConfigDto>;
+}

--- a/ahjoorxmr/src/groups/entities/group-template.entity.ts
+++ b/ahjoorxmr/src/groups/entities/group-template.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  DeleteDateColumn,
+  Index,
+} from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Template configuration interface for storing group template settings as JSONB.
+ * Captures all reusable group configuration parameters.
+ */
+export interface GroupTemplateConfig {
+  contributionAmount: string;
+  roundDuration: number;
+  totalRounds: number;
+  maxMembers?: number;
+  minMembers: number;
+  assetCode?: string;
+  assetIssuer?: string | null;
+  payoutOrderStrategy?: string;
+  penaltyRate?: number;
+  gracePeriodHours?: number;
+  timezone?: string | null;
+}
+
+/**
+ * GroupTemplate entity representing a reusable configuration preset for creating groups.
+ * Owned by a user and can be public or private.
+ */
+@Entity('group_templates')
+@Index('idx_group_templates_owner_id', ['ownerId'])
+@Index('idx_group_templates_public', ['isPublic'], { where: '"isPublic" = true' })
+export class GroupTemplate extends BaseEntity {
+  @Column('varchar', { length: 255 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 1000, nullable: true, default: null })
+  description: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  isPublic: boolean;
+
+  @Column({ type: 'jsonb' })
+  config: GroupTemplateConfig;
+
+  @Column({ type: 'uuid' })
+  ownerId: string;
+
+  @Column({ type: 'int', default: 0 })
+  usageCount: number;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date | null;
+
+  @ManyToOne(() => User, { eager: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ownerId' })
+  owner: User;
+}

--- a/ahjoorxmr/src/groups/group-templates.controller.spec.ts
+++ b/ahjoorxmr/src/groups/group-templates.controller.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupTemplatesController } from './group-templates.controller';
+import { GroupTemplatesService } from './group-templates.service';
+import { CreateGroupTemplateDto } from './dto/group-template.dto';
+import { GroupTemplate, GroupTemplateConfig } from './entities/group-template.entity';
+
+describe('GroupTemplatesController', () => {
+  let controller: GroupTemplatesController;
+  let service: GroupTemplatesService;
+
+  const mockUserId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockTemplateId = '550e8400-e29b-41d4-a716-446655440003';
+
+  const mockConfig: GroupTemplateConfig = {
+    contributionAmount: '100.00',
+    roundDuration: 2592000,
+    totalRounds: 12,
+    maxMembers: 12,
+    minMembers: 3,
+    assetCode: 'USDC',
+    assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    payoutOrderStrategy: 'SEQUENTIAL',
+    penaltyRate: 0.05,
+    gracePeriodHours: 24,
+    timezone: 'UTC',
+  };
+
+  const mockTemplate: GroupTemplate = {
+    id: mockTemplateId,
+    name: 'Test Template',
+    description: 'A test template',
+    isPublic: false,
+    config: mockConfig,
+    ownerId: mockUserId,
+    usageCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    owner: null,
+  };
+
+  const mockRequest = { user: { id: mockUserId } };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupTemplatesController],
+      providers: [
+        {
+          provide: GroupTemplatesService,
+          useValue: {
+            createTemplate: jest.fn(),
+            findTemplates: jest.fn(),
+            findTemplateById: jest.fn(),
+            updateTemplate: jest.fn(),
+            deleteTemplate: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<GroupTemplatesController>(
+      GroupTemplatesController,
+    );
+    service = module.get<GroupTemplatesService>(GroupTemplatesService);
+  });
+
+  describe('createTemplate', () => {
+    it('should create a template', async () => {
+      const createDto: CreateGroupTemplateDto = {
+        name: 'Test Template',
+        description: 'A test template',
+        isPublic: false,
+        config: mockConfig as any,
+      };
+
+      jest.spyOn(service, 'createTemplate').mockResolvedValue(mockTemplate);
+
+      const result = await controller.createTemplate(mockRequest as any, createDto);
+
+      expect(service.createTemplate).toHaveBeenCalledWith(createDto, mockUserId);
+      expect(result.id).toBe(mockTemplateId);
+      expect(result.name).toBe('Test Template');
+    });
+  });
+
+  describe('getTemplates', () => {
+    it('should return paginated templates', async () => {
+      const mockResult = {
+        data: [mockTemplate],
+        total: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      jest.spyOn(service, 'findTemplates').mockResolvedValue(mockResult);
+
+      const result = await controller.getTemplates(
+        mockRequest as any,
+        1,
+        10,
+        undefined,
+      );
+
+      expect(service.findTemplates).toHaveBeenCalledWith(
+        mockUserId,
+        1,
+        10,
+        undefined,
+      );
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('should support search parameter', async () => {
+      const mockResult = {
+        data: [mockTemplate],
+        total: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      jest.spyOn(service, 'findTemplates').mockResolvedValue(mockResult);
+
+      await controller.getTemplates(mockRequest as any, 1, 10, 'USDC');
+
+      expect(service.findTemplates).toHaveBeenCalledWith(
+        mockUserId,
+        1,
+        10,
+        'USDC',
+      );
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('should return a single template', async () => {
+      jest
+        .spyOn(service, 'findTemplateById')
+        .mockResolvedValue(mockTemplate);
+
+      const result = await controller.getTemplate(
+        mockRequest as any,
+        mockTemplateId,
+      );
+
+      expect(service.findTemplateById).toHaveBeenCalledWith(
+        mockTemplateId,
+        mockUserId,
+      );
+      expect(result.id).toBe(mockTemplateId);
+    });
+  });
+
+  describe('updateTemplate', () => {
+    it('should update a template', async () => {
+      const updateDto = { name: 'Updated Template' };
+      const updatedTemplate = { ...mockTemplate, ...updateDto };
+
+      jest
+        .spyOn(service, 'updateTemplate')
+        .mockResolvedValue(updatedTemplate);
+
+      const result = await controller.updateTemplate(
+        mockRequest as any,
+        mockTemplateId,
+        updateDto as any,
+      );
+
+      expect(service.updateTemplate).toHaveBeenCalledWith(
+        mockTemplateId,
+        updateDto,
+        mockUserId,
+      );
+      expect(result.name).toBe('Updated Template');
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('should delete a template', async () => {
+      jest.spyOn(service, 'deleteTemplate').mockResolvedValue(undefined);
+
+      await controller.deleteTemplate(mockRequest as any, mockTemplateId);
+
+      expect(service.deleteTemplate).toHaveBeenCalledWith(
+        mockTemplateId,
+        mockUserId,
+      );
+    });
+  });
+});

--- a/ahjoorxmr/src/groups/group-templates.controller.ts
+++ b/ahjoorxmr/src/groups/group-templates.controller.ts
@@ -1,0 +1,343 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+  UseGuards,
+  Request,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
+import { GroupTemplatesService } from './group-templates.service';
+import {
+  CreateGroupTemplateDto,
+  UpdateGroupTemplateDto,
+} from './dto/group-template.dto';
+import {
+  GroupTemplateResponseDto,
+  PaginatedGroupTemplatesResponseDto,
+} from './dto/group-template-response.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { ApiKeyAuthGuard } from '../api-keys/guards/api-key-auth.guard';
+import { KeyScopeGuard } from '../api-keys/guards/key-scope.guard';
+import { RequireKeyScope } from '../api-keys/decorators/require-key-scope.decorator';
+import { KeyScope } from '../api-keys/key-scope.enum';
+import { AuditLog } from '../audit/decorators/audit-log.decorator';
+import { ErrorResponseDto } from '../common/dto/error-response.dto';
+import { GroupTemplate } from './entities/group-template.entity';
+
+/**
+ * Controller for managing group templates.
+ * Provides REST API endpoints for creating, listing, updating, and deleting group templates.
+ */
+@ApiTags('Group Templates')
+@Controller('group-templates')
+@UseGuards(KeyScopeGuard)
+export class GroupTemplatesController {
+  constructor(private readonly groupTemplatesService: GroupTemplatesService) {}
+
+  /**
+   * Creates a new group template from scratch or cloned from an existing group.
+   *
+   * @param req - Authenticated request object
+   * @param createDto - Template creation payload
+   * @returns The created template
+   */
+  @Post()
+  @UseGuards(JwtAuthGuard, ApiKeyAuthGuard)
+  @RequireKeyScope(KeyScope.WRITE_GROUPS)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new group template',
+    description:
+      'Creates a new group template from scratch or cloned from an existing group via ?fromGroupId=',
+  })
+  @ApiBody({ type: CreateGroupTemplateDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Template created successfully',
+    type: GroupTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid input data',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - JWT token required',
+    type: ErrorResponseDto,
+  })
+  @AuditLog({ action: 'CREATE', resource: 'GROUP_TEMPLATE' })
+  async createTemplate(
+    @Request() req: { user: { id: string } },
+    @Body() createDto: CreateGroupTemplateDto,
+  ): Promise<GroupTemplateResponseDto> {
+    const template = await this.groupTemplatesService.createTemplate(
+      createDto,
+      req.user.id,
+    );
+    return this.toResponse(template);
+  }
+
+  /**
+   * Returns paginated list of templates accessible to the user.
+   * User sees: their own templates + all public templates.
+   *
+   * @param req - Authenticated request object
+   * @param page - Page number (default: 1)
+   * @param limit - Items per page (default: 10)
+   * @param search - Optional search string to filter by name/description
+   * @returns Paginated list of templates
+   */
+  @Get()
+  @UseGuards(JwtAuthGuard, ApiKeyAuthGuard)
+  @RequireKeyScope(KeyScope.READ_GROUPS)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get group templates',
+    description:
+      'Returns caller own templates plus all public templates; supports ?search= query param',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (default: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 10)',
+    example: 10,
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Search string to filter templates by name or description',
+    example: 'USDC',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of templates',
+    type: PaginatedGroupTemplatesResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - JWT token required',
+    type: ErrorResponseDto,
+  })
+  async getTemplates(
+    @Request() req: { user: { id: string } },
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('search') search?: string,
+  ): Promise<PaginatedGroupTemplatesResponseDto> {
+    const result = await this.groupTemplatesService.findTemplates(
+      req.user.id,
+      page,
+      limit,
+      search,
+    );
+    return {
+      data: result.data.map((t) => this.toResponse(t)),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+    };
+  }
+
+  /**
+   * Returns a single template (own or public).
+   *
+   * @param req - Authenticated request object
+   * @param id - Template UUID
+   * @returns The template
+   */
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, ApiKeyAuthGuard)
+  @RequireKeyScope(KeyScope.READ_GROUPS)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get a single group template',
+    description: 'Returns a single template if accessible to the user',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Template UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Template found',
+    type: GroupTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - template is private and not owned by you',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Template not found',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - JWT token required',
+    type: ErrorResponseDto,
+  })
+  async getTemplate(
+    @Request() req: { user: { id: string } },
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<GroupTemplateResponseDto> {
+    const template = await this.groupTemplatesService.findTemplateById(
+      id,
+      req.user.id,
+    );
+    return this.toResponse(template);
+  }
+
+  /**
+   * Updates a template (owner only).
+   *
+   * @param req - Authenticated request object
+   * @param id - Template UUID
+   * @param updateDto - Partial template update
+   * @returns The updated template
+   */
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, ApiKeyAuthGuard)
+  @RequireKeyScope(KeyScope.WRITE_GROUPS)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update a group template',
+    description: 'Updates a template; only the owner can update their templates',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Template UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiBody({ type: UpdateGroupTemplateDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Template updated successfully',
+    type: GroupTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - you can only update your own templates',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Template not found',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - JWT token required',
+    type: ErrorResponseDto,
+  })
+  @AuditLog({ action: 'UPDATE', resource: 'GROUP_TEMPLATE' })
+  async updateTemplate(
+    @Request() req: { user: { id: string } },
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateDto: UpdateGroupTemplateDto,
+  ): Promise<GroupTemplateResponseDto> {
+    const template = await this.groupTemplatesService.updateTemplate(
+      id,
+      updateDto,
+      req.user.id,
+    );
+    return this.toResponse(template);
+  }
+
+  /**
+   * Soft-deletes a template (owner only).
+   * Deleting a template does not affect groups already created from it.
+   *
+   * @param req - Authenticated request object
+   * @param id - Template UUID
+   */
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, ApiKeyAuthGuard)
+  @RequireKeyScope(KeyScope.WRITE_GROUPS)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete a group template',
+    description:
+      'Soft-deletes a template; only the owner can delete their templates. Deleting a template does not affect groups created from it.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Template UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Template deleted successfully',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - you can only delete your own templates',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Template not found',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - JWT token required',
+    type: ErrorResponseDto,
+  })
+  @AuditLog({ action: 'DELETE', resource: 'GROUP_TEMPLATE' })
+  async deleteTemplate(
+    @Request() req: { user: { id: string } },
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.groupTemplatesService.deleteTemplate(id, req.user.id);
+  }
+
+  /**
+   * Converts a GroupTemplate entity to a response DTO.
+   */
+  private toResponse(template: GroupTemplate): GroupTemplateResponseDto {
+    return {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      isPublic: template.isPublic,
+      config: template.config as any,
+      ownerId: template.ownerId,
+      usageCount: template.usageCount,
+      createdAt: template.createdAt?.toISOString() ?? new Date().toISOString(),
+      updatedAt: template.updatedAt?.toISOString() ?? new Date().toISOString(),
+    };
+  }
+}

--- a/ahjoorxmr/src/groups/group-templates.service.spec.ts
+++ b/ahjoorxmr/src/groups/group-templates.service.spec.ts
@@ -1,0 +1,405 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import {
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { GroupTemplatesService } from './group-templates.service';
+import { GroupTemplate, GroupTemplateConfig } from './entities/group-template.entity';
+import { Group } from './entities/group.entity';
+import { WinstonLogger } from '../common/logger/winston.logger';
+import { CreateGroupTemplateDto } from './dto/group-template.dto';
+import { GroupStatus } from './entities/group-status.enum';
+import { PayoutOrderStrategy } from './entities/payout-order-strategy.enum';
+
+describe('GroupTemplatesService', () => {
+  let service: GroupTemplatesService;
+  let templateRepository: Repository<GroupTemplate>;
+  let groupRepository: Repository<Group>;
+  let logger: WinstonLogger;
+  let dataSource: DataSource;
+
+  const mockUserId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockOwnerId = '550e8400-e29b-41d4-a716-446655440001';
+  const mockGroupId = '550e8400-e29b-41d4-a716-446655440002';
+  const mockTemplateId = '550e8400-e29b-41d4-a716-446655440003';
+
+  const mockConfig: GroupTemplateConfig = {
+    contributionAmount: '100.00',
+    roundDuration: 2592000,
+    totalRounds: 12,
+    maxMembers: 12,
+    minMembers: 3,
+    assetCode: 'USDC',
+    assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    payoutOrderStrategy: 'SEQUENTIAL',
+    penaltyRate: 0.05,
+    gracePeriodHours: 24,
+    timezone: 'UTC',
+  };
+
+  const mockTemplate: GroupTemplate = {
+    id: mockTemplateId,
+    name: 'Test Template',
+    description: 'A test template',
+    isPublic: false,
+    config: mockConfig,
+    ownerId: mockOwnerId,
+    usageCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    owner: null,
+  };
+
+  const mockGroup: Group = {
+    id: mockGroupId,
+    name: 'Test Group',
+    contractAddress: null,
+    adminWallet: 'GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON',
+    contributionAmount: '100.00',
+    token: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    assetCode: 'USDC',
+    assetIssuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    roundDuration: 2592000,
+    status: GroupStatus.PENDING,
+    currentRound: 0,
+    totalRounds: 12,
+    payoutOrderStrategy: PayoutOrderStrategy.SEQUENTIAL,
+    minMembers: 3,
+    maxMembers: 12,
+    staleAt: null,
+    startDate: null,
+    endDate: null,
+    timezone: 'UTC',
+    penaltyRate: 0.05,
+    gracePeriodHours: 24,
+    deletedAt: null,
+    memberships: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GroupTemplatesService,
+        {
+          provide: getRepositoryToken(GroupTemplate),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Group),
+          useClass: Repository,
+        },
+        {
+          provide: WinstonLogger,
+          useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+        },
+        {
+          provide: DataSource,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = module.get<GroupTemplatesService>(GroupTemplatesService);
+    templateRepository = module.get<Repository<GroupTemplate>>(
+      getRepositoryToken(GroupTemplate),
+    );
+    groupRepository = module.get<Repository<Group>>(getRepositoryToken(Group));
+    logger = module.get<WinstonLogger>(WinstonLogger);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  describe('createTemplate', () => {
+    it('should create a template from scratch', async () => {
+      const createDto: CreateGroupTemplateDto = {
+        name: 'Test Template',
+        description: 'A test template',
+        isPublic: false,
+        config: mockConfig as any,
+      };
+
+      jest.spyOn(templateRepository, 'create').mockReturnValue(mockTemplate);
+      jest.spyOn(templateRepository, 'save').mockResolvedValue(mockTemplate);
+
+      const result = await service.createTemplate(createDto, mockUserId);
+
+      expect(result).toEqual(mockTemplate);
+      expect(templateRepository.create).toHaveBeenCalledWith({
+        name: createDto.name,
+        description: createDto.description,
+        isPublic: createDto.isPublic,
+        config: mockConfig,
+        ownerId: mockUserId,
+        usageCount: 0,
+      });
+      expect(templateRepository.save).toHaveBeenCalledWith(mockTemplate);
+    });
+
+    it('should create a template cloned from an existing group', async () => {
+      const createDto: CreateGroupTemplateDto = {
+        name: 'Cloned Template',
+        description: 'Cloned from group',
+        isPublic: false,
+        fromGroupId: mockGroupId,
+      };
+
+      jest.spyOn(groupRepository, 'findOne').mockResolvedValue(mockGroup);
+      jest.spyOn(templateRepository, 'create').mockReturnValue(mockTemplate);
+      jest.spyOn(templateRepository, 'save').mockResolvedValue(mockTemplate);
+
+      const result = await service.createTemplate(createDto, mockUserId);
+
+      expect(groupRepository.findOne).toHaveBeenCalledWith({
+        where: { id: mockGroupId },
+      });
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('should throw error if fromGroupId group not found', async () => {
+      const createDto: CreateGroupTemplateDto = {
+        name: 'Cloned Template',
+        isPublic: false,
+        fromGroupId: 'non-existent-id',
+      };
+
+      jest.spyOn(groupRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.createTemplate(createDto, mockUserId),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw error if neither config nor fromGroupId is provided', async () => {
+      const createDto: CreateGroupTemplateDto = {
+        name: 'Invalid Template',
+        isPublic: false,
+      };
+
+      await expect(
+        service.createTemplate(createDto, mockUserId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findTemplates', () => {
+    it('should return user own templates and public templates', async () => {
+      const templates = [mockTemplate];
+      const mockQueryBuilder: any = {
+        where: jest.fn().returnThis(),
+        andWhere: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        getManyAndCount: jest.fn().resolvedValue([templates, 1]),
+      };
+
+      jest
+        .spyOn(templateRepository, 'createQueryBuilder')
+        .mockReturnValue(mockQueryBuilder);
+
+      const result = await service.findTemplates(mockUserId, 1, 10);
+
+      expect(result.data).toEqual(templates);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(10);
+    });
+
+    it('should filter templates by search string', async () => {
+      const templates = [mockTemplate];
+      const mockQueryBuilder: any = {
+        where: jest.fn().returnThis(),
+        andWhere: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        getManyAndCount: jest.fn().resolvedValue([templates, 1]),
+      };
+
+      jest
+        .spyOn(templateRepository, 'createQueryBuilder')
+        .mockReturnValue(mockQueryBuilder);
+
+      const result = await service.findTemplates(
+        mockUserId,
+        1,
+        10,
+        'USDC',
+      );
+
+      expect(result.data).toEqual(templates);
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalled();
+    });
+  });
+
+  describe('findTemplateById', () => {
+    it('should return template if user is owner', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+
+      const result = await service.findTemplateById(
+        mockTemplateId,
+        mockOwnerId,
+      );
+
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('should return public template even if not owner', async () => {
+      const publicTemplate = { ...mockTemplate, isPublic: true };
+      jest
+        .spyOn(templateRepository, 'findOne')
+        .mockResolvedValue(publicTemplate);
+
+      const result = await service.findTemplateById(
+        mockTemplateId,
+        mockUserId,
+      );
+
+      expect(result).toEqual(publicTemplate);
+    });
+
+    it('should throw ForbiddenException if template is private and not owner', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+
+      await expect(
+        service.findTemplateById(mockTemplateId, mockUserId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if template not found', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.findTemplateById(mockTemplateId, mockUserId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateTemplate', () => {
+    it('should update template if user is owner', async () => {
+      const updateDto = { name: 'Updated Template' };
+      const updatedTemplate = { ...mockTemplate, ...updateDto };
+
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(templateRepository, 'save').mockResolvedValue(updatedTemplate);
+
+      const result = await service.updateTemplate(
+        mockTemplateId,
+        updateDto as any,
+        mockOwnerId,
+      );
+
+      expect(result.name).toBe('Updated Template');
+      expect(templateRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if user is not owner', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+
+      await expect(
+        service.updateTemplate(
+          mockTemplateId,
+          { name: 'Updated' } as any,
+          mockUserId,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if template not found', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.updateTemplate(
+          mockTemplateId,
+          { name: 'Updated' } as any,
+          mockOwnerId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('should soft-delete template if user is owner', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(templateRepository, 'softRemove').mockResolvedValue(mockTemplate);
+
+      await service.deleteTemplate(mockTemplateId, mockOwnerId);
+
+      expect(templateRepository.softRemove).toHaveBeenCalledWith(mockTemplate);
+    });
+
+    it('should throw ForbiddenException if user is not owner', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(mockTemplate);
+
+      await expect(
+        service.deleteTemplate(mockTemplateId, mockUserId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if template not found', async () => {
+      jest.spyOn(templateRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.deleteTemplate(mockTemplateId, mockOwnerId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('incrementUsageCount', () => {
+    it('should increment usage count atomically', async () => {
+      jest.spyOn(templateRepository, 'increment').mockResolvedValue({} as any);
+
+      await service.incrementUsageCount(mockTemplateId);
+
+      expect(templateRepository.increment).toHaveBeenCalledWith(
+        { id: mockTemplateId },
+        'usageCount',
+        1,
+      );
+    });
+  });
+
+  describe('mergeTemplateConfig', () => {
+    it('should merge template config with explicit DTO fields overriding template values', () => {
+      const createDto = {
+        name: 'New Group',
+        token: 'TOKEN',
+        contributionAmount: '200.00', // Override template
+        roundDuration: 0, // Use default from template
+        totalRounds: 0, // Use default from template
+        minMembers: 0, // Use default from template
+      } as any;
+
+      const result = service.mergeTemplateConfig(mockTemplate, createDto);
+
+      expect(result.contributionAmount).toBe('200.00'); // Explicit value wins
+      expect(result.roundDuration).toBe(mockConfig.roundDuration); // Template default
+      expect(result.assetCode).toBe(mockConfig.assetCode); // Template default
+    });
+
+    it('should apply all template defaults when DTO values are falsy', () => {
+      const createDto = {
+        name: 'New Group',
+        token: 'TOKEN',
+        roundDuration: 0,
+        totalRounds: 0,
+        minMembers: 0,
+      } as any;
+
+      const result = service.mergeTemplateConfig(mockTemplate, createDto);
+
+      expect(result.contributionAmount).toBe(mockConfig.contributionAmount);
+      expect(result.assetCode).toBe(mockConfig.assetCode);
+      expect(result.assetIssuer).toBe(mockConfig.assetIssuer);
+      expect(result.payoutOrderStrategy).toBe(mockConfig.payoutOrderStrategy);
+      expect(result.penaltyRate).toBe(mockConfig.penaltyRate);
+      expect(result.gracePeriodHours).toBe(mockConfig.gracePeriodHours);
+      expect(result.timezone).toBe(mockConfig.timezone);
+    });
+  });
+});

--- a/ahjoorxmr/src/groups/group-templates.service.ts
+++ b/ahjoorxmr/src/groups/group-templates.service.ts
@@ -1,0 +1,410 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { GroupTemplate, GroupTemplateConfig } from './entities/group-template.entity';
+import { CreateGroupTemplateDto, UpdateGroupTemplateDto } from './dto/group-template.dto';
+import { Group } from './entities/group.entity';
+import { WinstonLogger } from '../common/logger/winston.logger';
+import { CreateGroupDto } from './dto/create-group.dto';
+
+/**
+ * Service for managing group configuration templates.
+ * Enables admins to save, share, and reuse group settings.
+ */
+@Injectable()
+export class GroupTemplatesService {
+  constructor(
+    @InjectRepository(GroupTemplate)
+    private readonly templateRepository: Repository<GroupTemplate>,
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
+    private readonly logger: WinstonLogger,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /**
+   * Creates a new group template from scratch or cloned from an existing group.
+   *
+   * @param createDto - Template creation data
+   * @param userId - UUID of the authenticated user (template owner)
+   * @returns The created GroupTemplate entity
+   * @throws BadRequestException if fromGroupId is provided but group not found
+   */
+  async createTemplate(
+    createDto: CreateGroupTemplateDto,
+    userId: string,
+  ): Promise<GroupTemplate> {
+    this.logger.log(
+      `Creating group template "${createDto.name}" for user ${userId}`,
+      'GroupTemplatesService',
+    );
+
+    try {
+      let config: GroupTemplateConfig;
+
+      // If cloning from existing group, extract its config
+      if (createDto.fromGroupId) {
+        const sourceGroup = await this.groupRepository.findOne({
+          where: { id: createDto.fromGroupId },
+        });
+
+        if (!sourceGroup) {
+          throw new BadRequestException(
+            `Source group ${createDto.fromGroupId} not found`,
+          );
+        }
+
+        config = this.extractGroupConfig(sourceGroup);
+      } else if (createDto.config) {
+        config = createDto.config as any;
+      } else {
+        throw new BadRequestException(
+          'Either config or fromGroupId must be provided',
+        );
+      }
+
+      const template = this.templateRepository.create({
+        name: createDto.name,
+        description: createDto.description ?? null,
+        isPublic: createDto.isPublic ?? false,
+        config,
+        ownerId: userId,
+        usageCount: 0,
+      });
+
+      const saved = await this.templateRepository.save(template);
+
+      this.logger.log(
+        `Group template created with id ${saved.id} for user ${userId}`,
+        'GroupTemplatesService',
+      );
+
+      return saved;
+    } catch (error) {
+      this.logger.error(
+        `Failed to create group template for user ${userId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Returns paginated list of templates.
+   * User sees: their own private templates + all public templates.
+   *
+   * @param userId - UUID of the authenticated user
+   * @param page - Page number (1-indexed)
+   * @param limit - Items per page
+   * @param search - Optional search string to filter by name/description
+   * @returns Paginated result with templates
+   */
+  async findTemplates(
+    userId: string,
+    page: number = 1,
+    limit: number = 10,
+    search?: string,
+  ): Promise<{ data: GroupTemplate[]; total: number; page: number; limit: number }> {
+    this.logger.log(
+      `Fetching templates for user ${userId} page=${page} limit=${limit} search=${search}`,
+      'GroupTemplatesService',
+    );
+
+    try {
+      const skip = (page - 1) * limit;
+
+      const qb = this.templateRepository
+        .createQueryBuilder('template')
+        .where('(template.ownerId = :userId OR template.isPublic = true)', {
+          userId,
+        })
+        .orderBy('template.createdAt', 'DESC')
+        .skip(skip)
+        .take(limit);
+
+      // Apply search filter if provided
+      if (search) {
+        qb.andWhere(
+          '(template.name ILIKE :search OR template.description ILIKE :search)',
+          { search: `%${search}%` },
+        );
+      }
+
+      const [data, total] = await qb.getManyAndCount();
+
+      this.logger.log(
+        `Found ${total} template(s) for user ${userId}; returning page ${page}`,
+        'GroupTemplatesService',
+      );
+
+      return { data, total, page, limit };
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch templates for user ${userId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Returns a single template if visible to the user.
+   * A template is visible if: user is the owner OR template is public.
+   *
+   * @param templateId - UUID of the template
+   * @param userId - UUID of the authenticated user
+   * @returns The GroupTemplate entity
+   * @throws NotFoundException if template not found or not visible
+   */
+  async findTemplateById(templateId: string, userId: string): Promise<GroupTemplate> {
+    this.logger.log(
+      `Fetching template ${templateId} for user ${userId}`,
+      'GroupTemplatesService',
+    );
+
+    try {
+      const template = await this.templateRepository.findOne({
+        where: { id: templateId },
+      });
+
+      if (!template) {
+        throw new NotFoundException(`Template ${templateId} not found`);
+      }
+
+      // Check visibility: owner can see their own, others can only see public
+      if (template.ownerId !== userId && !template.isPublic) {
+        throw new ForbiddenException(
+          'You do not have permission to view this template',
+        );
+      }
+
+      return template;
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch template ${templateId} for user ${userId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Updates an existing template.
+   * Only the owner can update their own templates.
+   *
+   * @param templateId - UUID of the template
+   * @param updateDto - Partial template update data
+   * @param userId - UUID of the authenticated user
+   * @returns The updated GroupTemplate entity
+   * @throws NotFoundException if template not found
+   * @throws ForbiddenException if user is not the owner
+   */
+  async updateTemplate(
+    templateId: string,
+    updateDto: UpdateGroupTemplateDto,
+    userId: string,
+  ): Promise<GroupTemplate> {
+    this.logger.log(
+      `Updating template ${templateId} by user ${userId}`,
+      'GroupTemplatesService',
+    );
+
+    try {
+      const template = await this.templateRepository.findOne({
+        where: { id: templateId },
+      });
+
+      if (!template) {
+        throw new NotFoundException(`Template ${templateId} not found`);
+      }
+
+      if (template.ownerId !== userId) {
+        throw new ForbiddenException('You can only update your own templates');
+      }
+
+      // Update fields if provided
+      if (updateDto.name !== undefined) {
+        template.name = updateDto.name;
+      }
+      if (updateDto.description !== undefined) {
+        template.description = updateDto.description;
+      }
+      if (updateDto.isPublic !== undefined) {
+        template.isPublic = updateDto.isPublic;
+      }
+      if (updateDto.config !== undefined) {
+        // Merge partial config updates
+        template.config = { ...template.config, ...updateDto.config };
+      }
+
+      const updated = await this.templateRepository.save(template);
+
+      this.logger.log(
+        `Template ${templateId} updated by user ${userId}`,
+        'GroupTemplatesService',
+      );
+
+      return updated;
+    } catch (error) {
+      this.logger.error(
+        `Failed to update template ${templateId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Soft-deletes a template.
+   * Only the owner can delete their own templates.
+   * Deleting a template does not affect groups created from it.
+   *
+   * @param templateId - UUID of the template
+   * @param userId - UUID of the authenticated user
+   * @throws NotFoundException if template not found
+   * @throws ForbiddenException if user is not the owner
+   */
+  async deleteTemplate(templateId: string, userId: string): Promise<void> {
+    this.logger.log(
+      `Deleting template ${templateId} by user ${userId}`,
+      'GroupTemplatesService',
+    );
+
+    try {
+      const template = await this.templateRepository.findOne({
+        where: { id: templateId },
+      });
+
+      if (!template) {
+        throw new NotFoundException(`Template ${templateId} not found`);
+      }
+
+      if (template.ownerId !== userId) {
+        throw new ForbiddenException('You can only delete your own templates');
+      }
+
+      await this.templateRepository.softRemove(template);
+
+      this.logger.log(
+        `Template ${templateId} soft-deleted by user ${userId}`,
+        'GroupTemplatesService',
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete template ${templateId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Atomically increments the usage count of a template.
+   * Called after a group is successfully created from this template.
+   *
+   * @param templateId - UUID of the template
+   */
+  async incrementUsageCount(templateId: string): Promise<void> {
+    this.logger.log(`Incrementing usage count for template ${templateId}`, 'GroupTemplatesService');
+
+    try {
+      await this.templateRepository.increment(
+        { id: templateId },
+        'usageCount',
+        1,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to increment usage count for template ${templateId}: ${error.message}`,
+        error.stack,
+        'GroupTemplatesService',
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Merges template configuration into the group creation DTO.
+   * Explicit DTO fields always override template defaults.
+   *
+   * @param template - The GroupTemplate entity
+   * @param createGroupDto - The incoming group creation DTO
+   * @returns Merged CreateGroupDto with template defaults applied
+   */
+  mergeTemplateConfig(
+    template: GroupTemplate,
+    createGroupDto: CreateGroupDto,
+  ): CreateGroupDto {
+    const merged = { ...createGroupDto };
+
+    // Apply template defaults only if not explicitly provided in DTO
+    if (!createGroupDto.contributionAmount) {
+      merged.contributionAmount = template.config.contributionAmount;
+    }
+    if (!createGroupDto.roundDuration) {
+      merged.roundDuration = template.config.roundDuration;
+    }
+    if (!createGroupDto.totalRounds) {
+      merged.totalRounds = template.config.totalRounds;
+    }
+    if (!createGroupDto.maxMembers) {
+      merged.maxMembers = template.config.maxMembers;
+    }
+    if (!createGroupDto.minMembers) {
+      merged.minMembers = template.config.minMembers;
+    }
+    if (!createGroupDto.assetCode && template.config.assetCode) {
+      merged.assetCode = template.config.assetCode;
+    }
+    if (!createGroupDto.assetIssuer && template.config.assetIssuer) {
+      merged.assetIssuer = template.config.assetIssuer;
+    }
+    if (!createGroupDto.payoutOrderStrategy && template.config.payoutOrderStrategy) {
+      merged.payoutOrderStrategy = template.config.payoutOrderStrategy;
+    }
+    if (!createGroupDto.penaltyRate && template.config.penaltyRate) {
+      merged.penaltyRate = template.config.penaltyRate;
+    }
+    if (!createGroupDto.gracePeriodHours && template.config.gracePeriodHours) {
+      merged.gracePeriodHours = template.config.gracePeriodHours;
+    }
+    if (!createGroupDto.timezone && template.config.timezone) {
+      merged.timezone = template.config.timezone;
+    }
+
+    return merged;
+  }
+
+  /**
+   * Extracts configuration from an existing group into template-compatible format.
+   *
+   * @param group - The Group entity
+   * @returns GroupTemplateConfig object
+   */
+  private extractGroupConfig(group: Group): GroupTemplateConfig {
+    return {
+      contributionAmount: group.contributionAmount,
+      roundDuration: group.roundDuration,
+      totalRounds: group.totalRounds,
+      maxMembers: group.maxMembers,
+      minMembers: group.minMembers,
+      assetCode: group.assetCode,
+      assetIssuer: group.assetIssuer,
+      payoutOrderStrategy: group.payoutOrderStrategy,
+      penaltyRate: Number(group.penaltyRate),
+      gracePeriodHours: group.gracePeriodHours,
+      timezone: group.timezone,
+    };
+  }
+}

--- a/ahjoorxmr/src/groups/groups.controller.ts
+++ b/ahjoorxmr/src/groups/groups.controller.ts
@@ -113,9 +113,11 @@ export class GroupsController {
     @Body() createGroupDto: CreateGroupDto,
   ): Promise<GroupResponseDto> {
     const adminWallet = req.user.walletAddress || req.user.id;
+    const userId = req.user.id;
     const group = await this.groupsService.createGroup(
       createGroupDto,
       adminWallet,
+      userId,
     );
     return this.toGroupResponse(group);
   }

--- a/ahjoorxmr/src/groups/groups.module.ts
+++ b/ahjoorxmr/src/groups/groups.module.ts
@@ -6,6 +6,7 @@ import { GroupsService } from './groups.service';
 import { RoundService } from './round.service';
 import { PayoutService } from './payout.service';
 import { Group } from './entities/group.entity';
+import { GroupTemplate } from './entities/group-template.entity';
 import { Membership } from '../memberships/entities/membership.entity';
 import { WinstonLogger } from '../common/logger/winston.logger';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -22,6 +23,8 @@ import { Announcement } from './entities/announcement.entity';
 import { AnnouncementsService } from './announcements.service';
 import { AnnouncementsController } from './announcements.controller';
 import { AuditModule } from '../audit/audit.module';
+import { GroupTemplatesService } from './group-templates.service';
+import { GroupTemplatesController } from './group-templates.controller';
 
 /**
  * GroupsModule manages ROSCA group entities in the database.
@@ -30,14 +33,14 @@ import { AuditModule } from '../audit/audit.module';
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Group, Membership, PayoutTransaction, GroupInvite, User, Announcement]),
+    TypeOrmModule.forFeature([Group, GroupTemplate, Membership, PayoutTransaction, GroupInvite, User, Announcement]),
     NotificationsModule,
     StellarModule,
     QueueModule,
     MailModule,
     AuditModule,
   ],
-  controllers: [GroupsController, GroupsV2Controller, GroupInviteController, AnnouncementsController],
+  controllers: [GroupsController, GroupsV2Controller, GroupInviteController, AnnouncementsController, GroupTemplatesController],
   providers: [
     GroupsService,
     RoundService,
@@ -46,7 +49,8 @@ import { AuditModule } from '../audit/audit.module';
     JwtAuthGuard,
     GroupInviteService,
     AnnouncementsService,
+    GroupTemplatesService,
   ],
-  exports: [GroupsService, RoundService, PayoutService, GroupInviteService],
+  exports: [GroupsService, RoundService, PayoutService, GroupInviteService, GroupTemplatesService],
 })
 export class GroupsModule {}

--- a/ahjoorxmr/src/groups/groups.service.ts
+++ b/ahjoorxmr/src/groups/groups.service.ts
@@ -21,6 +21,7 @@ import { StellarService } from '../stellar/stellar.service';
 import { TransferAdminDto } from './dto/transfer-admin.dto';
 import { MembershipStatus } from '../memberships/entities/membership-status.enum';
 import { AuditService } from '../audit/audit.service';
+import { GroupTemplatesService } from './group-templates.service';
 
 import { UseReadReplica } from '../common/decorators/read-replica.decorator';
 
@@ -43,19 +44,23 @@ export class GroupsService {
     private readonly auditService: AuditService,
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    private readonly groupTemplatesService: GroupTemplatesService,
   ) {}
 
   /**
    * Creates a new ROSCA group with status PENDING.
    * The adminWallet is taken from the authenticated user's wallet (passed in, not from DTO).
+   * If templateId is provided, template config is merged as defaults (explicit DTO fields override template values).
    *
    * @param createGroupDto - Group creation data
    * @param adminWallet - Wallet address of the authenticated admin user
+   * @param userId - UUID of the authenticated user (needed for template visibility check)
    * @returns The created Group entity
    */
   async createGroup(
     createGroupDto: CreateGroupDto,
     adminWallet: string,
+    userId?: string,
   ): Promise<Group> {
     this.logger.log(
       `Creating group "${createGroupDto.name}" for admin ${adminWallet}`,
@@ -63,21 +68,32 @@ export class GroupsService {
     );
 
     try {
-      const maxMembers =
-        createGroupDto.maxMembers ?? createGroupDto.totalRounds;
+      let finalDto = { ...createGroupDto };
 
-      if (maxMembers !== createGroupDto.totalRounds) {
+      // If templateId is provided, merge template config as defaults
+      if (createGroupDto.templateId && userId) {
+        const template = await this.groupTemplatesService.findTemplateById(
+          createGroupDto.templateId,
+          userId,
+        );
+        finalDto = this.groupTemplatesService.mergeTemplateConfig(template, finalDto);
+      }
+
+      const maxMembers =
+        finalDto.maxMembers ?? finalDto.totalRounds;
+
+      if (maxMembers !== finalDto.totalRounds) {
         throw new BadRequestException('maxMembers must equal totalRounds');
       }
 
-      if (createGroupDto.minMembers > maxMembers) {
+      if (finalDto.minMembers > maxMembers) {
         throw new BadRequestException(
           'minMembers must be less than or equal to maxMembers',
         );
       }
 
       // Validate asset code against allow-list
-      const assetCode = createGroupDto.assetCode ?? 'XLM';
+      const assetCode = finalDto.assetCode ?? 'XLM';
       const allowedRaw = this.configService.get<string>('ALLOWED_ASSET_CODES', 'XLM,USDC');
       const allowedCodes = allowedRaw.split(',').map((c) => c.trim().toUpperCase());
       if (!allowedCodes.includes(assetCode.toUpperCase())) {
@@ -86,20 +102,32 @@ export class GroupsService {
         );
       }
 
-      const assetIssuer = assetCode.toUpperCase() === 'XLM' ? null : (createGroupDto.assetIssuer ?? null);
+      const assetIssuer = assetCode.toUpperCase() === 'XLM' ? null : (finalDto.assetIssuer ?? null);
 
       const group = this.groupRepository.create({
-        ...createGroupDto,
+        ...finalDto,
         maxMembers,
         adminWallet,
         status: GroupStatus.PENDING,
         currentRound: 0,
-        contractAddress: createGroupDto.contractAddress ?? null,
+        contractAddress: finalDto.contractAddress ?? null,
         assetCode: assetCode.toUpperCase(),
         assetIssuer,
+        payoutOrderStrategy: finalDto.payoutOrderStrategy
+          ? (finalDto.payoutOrderStrategy as PayoutOrderStrategy)
+          : PayoutOrderStrategy.SEQUENTIAL,
+        penaltyRate: finalDto.penaltyRate ?? 0.05,
+        gracePeriodHours: finalDto.gracePeriodHours ?? 24,
       });
 
       const savedGroup = await this.groupRepository.save(group);
+
+      // Atomically increment template usage count if template was used
+      if (createGroupDto.templateId) {
+        await this.groupTemplatesService.incrementUsageCount(
+          createGroupDto.templateId,
+        );
+      }
 
       this.logger.log(
         `Group created with id ${savedGroup.id} for admin ${adminWallet}`,


### PR DESCRIPTION
Changes Made
Added group template creation and reuse system
Enabled creating templates from existing groups
Made config optional for fromGroupId flow
How to Test
Create a group template from existing group
Reuse template when creating a new group
Verify config is applied correctly                                                                                                                                                                 Closes #278